### PR TITLE
Use the class selected with the cursor for the Find Mixins action

### DIFF
--- a/src/main/java/com/demonwav/mcdev/platform/mixin/actions/FindMixinsAction.java
+++ b/src/main/java/com/demonwav/mcdev/platform/mixin/actions/FindMixinsAction.java
@@ -72,7 +72,7 @@ public class FindMixinsAction extends AnAction {
         }
 
         final PsiElement element = file.findElementAt(caret.getOffset());
-        final PsiClass classOfElement = McPsiUtil.getClassOfElement(element);
+        final PsiClass classOfElement = McPsiUtil.getClassOfElement(element, true);
 
         if (classOfElement == null) {
             return;

--- a/src/main/kotlin/com/demonwav/mcdev/util/McPsiUtil.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/McPsiUtil.kt
@@ -26,33 +26,31 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMember
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiReference
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.annotations.Contract
 import java.util.Collections
 import java.util.stream.Collectors
 
 @Contract(value = "null -> null", pure = true)
-fun getClassOfElement(element: PsiElement?): PsiClass? {
-    if (element == null) {
-        return null
-    }
-
-    if (element is PsiClass) {
-        return element
-    }
-
+fun getClassOfElement(element: PsiElement?, resolveReferences: Boolean = false): PsiClass? {
     var el = element
-    while (el?.parent != null) {
-        if (el.parent is PsiClass) {
-            return el.parent as PsiClass
+    while (el != null) {
+        if (resolveReferences && el is PsiReference) {
+            el = el.resolve()
         }
 
-        if (el.parent is PsiFile || el.parent is PsiDirectory) {
+        if (el is PsiClass) {
+            return el
+        }
+
+        if (el is PsiFile || el is PsiDirectory) {
             return null
         }
 
-        el = el.parent
+        el = el?.parent
     }
+
     return null
 }
 


### PR DESCRIPTION
Assuming I have a Mixin class open in the editor:

```java
@Mixin(Entity.class)
public abstract class MixinEntity {

}
```

When I right click the `Entity.class` part I'd expect the `Find mixins` action to search for other Mixins that target `Entity` and not for Mixins which target `MixinEntity`. With these changes it will attempt to resolve the selected reference before checking for mixins of the current class.

Since the changed method is also used in other contexts I'm not entirely sure if the change also breaks something else.