### PR TITLE
Add copy mixin target reference action

### DIFF
--- a/src/main/java/com/demonwav/mcdev/platform/mcp/util/McpUtil.java
+++ b/src/main/java/com/demonwav/mcdev/platform/mcp/util/McpUtil.java
@@ -10,6 +10,8 @@
 
 package com.demonwav.mcdev.platform.mcp.util;
 
+import com.demonwav.mcdev.util.McBytecodeUtilKt;
+
 import com.google.common.collect.Lists;
 import com.intellij.navigation.AnonymousElementProvider;
 import com.intellij.openapi.extensions.Extensions;
@@ -174,30 +176,6 @@ public final class McpUtil {
     @Nullable
     @Contract(value = "null -> null", pure = true)
     public static String getStringFromType(@Nullable PsiType type) {
-        if (type == null) {
-            return null;
-        }
-
-        if (type == PsiType.BYTE) {
-            return "B";
-        } else if (type == PsiType.CHAR) {
-            return "C";
-        } else if (type == PsiType.DOUBLE) {
-            return "D";
-        } else if (type == PsiType.FLOAT) {
-            return "F";
-        } else if (type == PsiType.INT) {
-            return "I";
-        } else if (type == PsiType.LONG) {
-            return "J";
-        } else if (type == PsiType.SHORT) {
-            return "S";
-        } else if (type == PsiType.BOOLEAN) {
-            return "Z";
-        } else if (type == PsiType.VOID) {
-            return "V";
-        } else {
-            return "L" + type.getCanonicalText(false).replaceAll("\\.", "/") + ";";
-        }
+        return type != null ? McBytecodeUtilKt.getDescriptor(type) : null;
     }
 }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/CopyMixinTargetReferenceAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/CopyMixinTargetReferenceAction.kt
@@ -1,0 +1,54 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2016 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.actions
+
+import com.demonwav.mcdev.util.appendDescriptor
+import com.demonwav.mcdev.util.findReferencedMember
+import com.demonwav.mcdev.util.getClassOfElement
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys.CARET
+import com.intellij.openapi.actionSystem.CommonDataKeys.PSI_FILE
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import java.awt.datatransfer.StringSelection
+
+class CopyMixinTargetReferenceAction : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent?) {
+        val project = e!!.project ?: return
+        val file = e.getData(PSI_FILE) ?: return
+        val caret = e.getData(CARET) ?: return
+
+        val element = file.findElementAt(caret.offset) ?: return
+        val member = findReferencedMember(element) ?: return
+        val classElement = getClassOfElement(member) ?: return
+        classElement.qualifiedName ?: return
+
+        val builder = StringBuilder()
+        classElement.appendDescriptor(builder).append(member.name)
+
+        when (member) {
+            is PsiField -> {
+                member.appendDescriptor(builder.append(':'))
+            }
+            is PsiMethod -> {
+                member.appendDescriptor(builder)
+            }
+        }
+
+        CopyPasteManager.getInstance().setContents(StringSelection(builder.toString()))
+        WindowManager.getInstance().getStatusBar(project).info = "Mixin target reference has been copied."
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/McBytecodeUtil.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/McBytecodeUtil.kt
@@ -1,0 +1,79 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2016 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util
+
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiType
+
+// Type
+
+val PsiType.internalName: String
+    get() = when (this) {
+        PsiType.BYTE -> "B"
+        PsiType.CHAR -> "C"
+        PsiType.DOUBLE -> "D"
+        PsiType.FLOAT -> "F"
+        PsiType.INT -> "I"
+        PsiType.LONG -> "J"
+        PsiType.SHORT -> "S"
+        PsiType.BOOLEAN -> "Z"
+        PsiType.VOID -> "V"
+        else -> canonicalText.replace('.', '/')
+    }
+
+val PsiType.descriptor: String
+    get() = appendDescriptor(StringBuilder()).toString()
+
+fun PsiType.appendDescriptor(builder: StringBuilder): StringBuilder {
+    val internalName = internalName
+    return if (internalName.length == 1) {
+        builder.append(internalName)
+    } else {
+        builder.append('L').append(internalName).append(';')
+    }
+}
+
+// Class
+
+val PsiClass.internalName: String?
+    get() = qualifiedName?.replace('.', '/')
+
+val PsiClass.descriptor: String?
+    get() {
+        val internalName = internalName ?: return null
+        return "L$internalName;"
+    }
+
+fun PsiClass.appendDescriptor(builder: StringBuilder): StringBuilder = builder.append('L').append(internalName!!).append(';')
+
+// Method
+
+val PsiMethod.descriptor: String
+    get() = appendDescriptor(StringBuilder()).toString()
+
+fun PsiMethod.appendDescriptor(builder: StringBuilder): StringBuilder {
+    builder.append('(')
+    for (parameter in parameterList.parameters) {
+        val type = parameter.typeElement?.type ?: continue
+        type.appendDescriptor(builder)
+    }
+    builder.append(')')
+    return (returnType ?: PsiType.VOID).appendDescriptor(builder)
+}
+
+// Field
+
+val PsiField.descriptor: String
+    get() = appendDescriptor(StringBuilder()).toString()
+
+fun PsiField.appendDescriptor(builder: StringBuilder): StringBuilder = type.appendDescriptor(builder)

--- a/src/main/kotlin/com/demonwav/mcdev/util/McPsiUtil.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/McPsiUtil.kt
@@ -35,21 +35,31 @@ import java.util.stream.Collectors
 @JvmOverloads
 @Contract(value = "null, _ -> null", pure = true)
 fun getClassOfElement(element: PsiElement?, resolveReferences: Boolean = false): PsiClass? {
+    return findElement(element, { it as? PsiClass }, resolveReferences)
+}
+
+fun findReferencedMember(element: PsiElement?): PsiMember? {
+    return findElement(element, { it as? PsiMember }, true)
+}
+
+@Contract(value = "null -> null", pure = true)
+private inline fun <T : PsiElement> findElement(element: PsiElement?, func: (PsiElement) -> T?, resolveReferences: Boolean): T? {
     var el = element
     while (el != null) {
         if (resolveReferences && el is PsiReference) {
-            el = el.resolve()
+            el = el.resolve() ?: return null
         }
 
-        if (el is PsiClass) {
-            return el
+        val result = func(el)
+        if (result != null) {
+            return result
         }
 
         if (el is PsiFile || el is PsiDirectory) {
             return null
         }
 
-        el = el?.parent
+        el = el.parent
     }
 
     return null

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -339,6 +339,11 @@
                 description="Find classes which mix into this class">
             <add-to-group relative-to-action="EditorPopupMenu2" anchor="after" group-id="EditorPopupMenu"/>
         </action>
+        <action class="com.demonwav.mcdev.platform.mixin.actions.CopyMixinTargetReferenceAction" id="CopyMixinTargetReferenceAction"
+                text="Copy Mixin target reference"
+                description="Copy the reference to the element for use in an injector">
+            <add-to-group relative-to-action="EditorPopupMenu2" anchor="after" group-id="EditorPopupMenu"/>
+        </action>
         <action class="com.demonwav.mcdev.platform.mcp.actions.FindSrgMappingAction" id="FindSrgMappingAction"
                 text="Get SRG Name"
                 description="Find the associated SRG mapping for this element">


### PR DESCRIPTION
Adds a new action that allows you to right click a reference to a field/method while browsing the Minecraft source and copies the target reference you would use in an `@Inject` to the clipboard.

Supported elements:
- Fields, e.g. `Lnet/minecraft/block/Block;translucent:Z`
- Methods, e.g. `Lnet/minecraft/block/Block;disableStats()Lnet/minecraft/block/Block;`

Not sure about the name for the action, feel free to suggest a better one.