### PR TITLE
Add Mixin debugging support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -75,6 +75,9 @@ dependencies {
         exclude(group = "org.jetbrains", module = "annotations")
     }
 
+    // Add tools.jar for the JDI API
+    compile(files(org.gradle.internal.jvm.Jvm.current().toolsJar))
+
     // Add an additional dependency on kotlin-runtime. It is essentially useless
     // (since kotlin-runtime is a transitive dependency of kotlin-stdlib-jre8)
     // but without kotlin-stdlib or kotlin-runtime on the classpath,

--- a/src/main/java/com/demonwav/mcdev/platform/mixin/util/MixinConstants.java
+++ b/src/main/java/com/demonwav/mcdev/platform/mixin/util/MixinConstants.java
@@ -15,6 +15,8 @@ import org.jetbrains.annotations.NotNull;
 public final class MixinConstants {
     private MixinConstants() {}
 
+    @NotNull public static final String SMAP_STRATUM = "Mixin";
+
     public static final class Annotations {
         private Annotations() {}
 

--- a/src/main/kotlin/com/demonwav/mcdev/inspection/IsCancelledInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/inspection/IsCancelledInspection.kt
@@ -11,6 +11,8 @@
 package com.demonwav.mcdev.inspection
 
 import com.demonwav.mcdev.platform.MinecraftModule
+import com.demonwav.mcdev.util.filterNotNull
+import com.demonwav.mcdev.util.mapNotNull
 
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleUtilCore
@@ -45,9 +47,8 @@ class IsCancelledInspection : BaseInspection() {
                 val instance = MinecraftModule.getInstance(module) ?: return
 
                 val useless = instance.modules.stream()
-                    .map { m -> m.checkUselessCancelCheck(expression) }
-                    .filter { Objects.nonNull(it) }
-                    .findAny()
+                        .mapNotNull { m -> m.checkUselessCancelCheck(expression) }
+                        .findAny()
 
                 if (!useless.isPresent) {
                     return

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinDebug.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinDebug.kt
@@ -1,0 +1,18 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2016 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.debug
+
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.UserDataHolder
+
+internal val MIXIN_DEBUG_KEY = Key.create<Boolean>("mixin.debug")
+
+internal fun UserDataHolder.hasMixinDebugKey(): Boolean = getUserData(MIXIN_DEBUG_KEY) == true

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinDebuggerClassFilterProvider.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinDebuggerClassFilterProvider.kt
@@ -1,0 +1,29 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2016 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.debug
+
+import com.intellij.ui.classFilter.ClassFilter
+import com.intellij.ui.classFilter.DebuggerClassFilterProvider
+
+/**
+ * Prevents stepping into Mixin's CallbackInfo class.
+ */
+class MixinDebuggerClassFilterProvider : DebuggerClassFilterProvider {
+
+    private val filters = listOf(
+            ClassFilter("org.spongepowered.asm.mixin.injection.callback.*")
+    )
+
+    override fun getFilters(): List<ClassFilter> {
+        return filters
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinPositionManager.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinPositionManager.kt
@@ -1,0 +1,110 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2016 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.debug
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants
+import com.demonwav.mcdev.platform.mixin.util.MixinUtils
+import com.demonwav.mcdev.util.getClassOfElement
+import com.demonwav.mcdev.util.mapNotNull
+import com.intellij.debugger.MultiRequestPositionManager
+import com.intellij.debugger.NoDataException
+import com.intellij.debugger.SourcePosition
+import com.intellij.debugger.engine.DebugProcess
+import com.intellij.debugger.engine.DebuggerUtils
+import com.intellij.debugger.engine.JVMNameUtil
+import com.intellij.debugger.requests.ClassPrepareRequestor
+import com.intellij.ide.highlighter.JavaFileType
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.fileTypes.FileType
+import com.sun.jdi.AbsentInformationException
+import com.sun.jdi.Location
+import com.sun.jdi.ReferenceType
+import com.sun.jdi.request.ClassPrepareRequest
+import java.util.stream.Stream
+import kotlin.streams.toList
+
+class MixinPositionManager(private val debugProcess: DebugProcess) : MultiRequestPositionManager {
+
+    override fun getAcceptedFileTypes(): Set<FileType> = setOf(JavaFileType.INSTANCE)
+
+    override fun getSourcePosition(location: Location?): SourcePosition? {
+        if (location != null) {
+            val type = location.declaringType()
+
+            // Check if mixin source map is present (Mixin sets the default stratum to Mixin)
+            if (type.defaultStratum() == MixinConstants.SMAP_STRATUM) {
+                // Return the correct PsiFile based on the source path in the SMAP
+                try {
+                    val path = location.sourcePath()
+
+                    // The source path is the package (separated by slashes) and class name with the ".java" file extension
+                    val className = path.removeSuffix(".java").replace('/', '.')
+
+                    // Lookup class based on its qualified name (TODO: Support for anonymous classes)
+                    val psiClass = DebuggerUtils.findClass(className, debugProcess.project, debugProcess.searchScope)
+                    if (psiClass != null) {
+                        // Mixin class found, return correct source file
+                        return SourcePosition.createFromLine(psiClass.navigationElement.containingFile, location.lineNumber() - 1)
+                    }
+                } catch (ignored: AbsentInformationException) {
+                }
+            }
+        }
+
+        throw NoDataException.INSTANCE
+    }
+
+    override fun getAllClasses(classPosition: SourcePosition): List<ReferenceType> {
+        return runReadAction {
+            findMatchingClasses(classPosition)
+                    .flatMap { name -> debugProcess.virtualMachineProxy.classesByName(name).stream() }
+                    .toList()
+        }
+    }
+
+    override fun locationsOfLine(type: ReferenceType, position: SourcePosition): List<Location> {
+        // Check if mixin source map is present (Mixin sets the default stratum to Mixin)
+        if (type.defaultStratum() == MixinConstants.SMAP_STRATUM) {
+            try {
+                // Return the line numbers from the correct source file
+                return type.locationsOfLine(MixinConstants.SMAP_STRATUM, position.file.name, position.line + 1)
+            } catch (ignored: AbsentInformationException) {
+            }
+        }
+
+        throw NoDataException.INSTANCE
+    }
+
+    override fun createPrepareRequest(requestor: ClassPrepareRequestor, position: SourcePosition): ClassPrepareRequest {
+        throw UnsupportedOperationException("This class implements MultiRequestPositionManager, corresponding createPrepareRequests version should be used")
+    }
+
+    override fun createPrepareRequests(requestor: ClassPrepareRequestor, position: SourcePosition): List<ClassPrepareRequest> {
+        return runReadAction {
+            findMatchingClasses(position)
+                    .mapNotNull { name -> debugProcess.requestsManager.createClassPrepareRequest(requestor, name) }
+                    .toList()
+        }
+    }
+
+    private fun findMatchingClasses(position: SourcePosition): Stream<String> {
+        val classElement = getClassOfElement(position.elementAt)
+        val targets = MixinUtils.getAllMixedClasses(classElement)
+        if (targets.isEmpty()) {
+            throw NoDataException.INSTANCE
+        }
+
+        return targets.values.stream()
+                // TODO: Support for anonymous classes
+                .mapNotNull(JVMNameUtil::getNonAnonymousClassName)
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinPositionManagerFactory.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinPositionManagerFactory.kt
@@ -1,0 +1,27 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2016 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.debug
+
+import com.intellij.debugger.PositionManager
+import com.intellij.debugger.PositionManagerFactory
+import com.intellij.debugger.engine.DebugProcess
+
+class MixinPositionManagerFactory : PositionManagerFactory() {
+
+    override fun createPositionManager(process: DebugProcess): PositionManager? {
+        return if (process.processHandler.hasMixinDebugKey()) {
+            MixinPositionManager(process)
+        } else {
+            null
+        }
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinRunConfigurationExtension.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/debug/MixinRunConfigurationExtension.kt
@@ -1,0 +1,52 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2016 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.debug
+
+import com.demonwav.mcdev.platform.MinecraftModule
+import com.demonwav.mcdev.platform.mixin.MixinModuleType
+import com.intellij.execution.RunConfigurationExtension
+import com.intellij.execution.configurations.DebuggingRunnerData
+import com.intellij.execution.configurations.JavaParameters
+import com.intellij.execution.configurations.ModuleBasedConfiguration
+import com.intellij.execution.configurations.RunConfigurationBase
+import com.intellij.execution.configurations.RunnerSettings
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.openapi.options.SettingsEditor
+import org.jdom.Element
+
+class MixinRunConfigurationExtension : RunConfigurationExtension() {
+
+    override fun isApplicableFor(configuration: RunConfigurationBase): Boolean {
+        return configuration is ModuleBasedConfiguration<*>
+    }
+
+    override fun <T : RunConfigurationBase?> updateJavaParameters(configuration: T, params: JavaParameters?, runnerSettings: RunnerSettings?) {}
+
+    override fun attachToProcess(configuration: RunConfigurationBase, handler: ProcessHandler, runnerSettings: RunnerSettings?) {
+        // Check if we are in a debug run
+        if (runnerSettings !is DebuggingRunnerData) {
+            return
+        }
+
+        val config = configuration as ModuleBasedConfiguration<*>
+        val module = config.configurationModule.module ?: return
+        if (MinecraftModule.getInstance(module)?.isOfType(MixinModuleType.getInstance()) == true) {
+            // Add marker data to enable Mixin debugger
+            handler.putUserData(MIXIN_DEBUG_KEY, true)
+        }
+    }
+
+    override fun readExternal(runConfiguration: RunConfigurationBase, element: Element) {}
+
+    override fun getEditorTitle(): String? = null
+    override fun <P : RunConfigurationBase?> createEditor(configuration: P): SettingsEditor<P>? = null
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/StreamUtil.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/StreamUtil.kt
@@ -1,0 +1,25 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2016 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util
+
+import java.util.stream.Stream
+
+/**
+ * Filters all `null` elements from the [Stream].
+ */
+@Suppress("UNCHECKED_CAST")
+fun <T> Stream<T?>.filterNotNull(): Stream<T> = filter({ it != null }) as Stream<T>
+
+/**
+ * Maps all elements with the specified mapper function and excludes all
+ * returned `null` elements from the [Stream].
+ */
+fun <T, R> Stream<T>.mapNotNull(mapper: (T) -> R?): Stream<R> = map(mapper).filterNotNull()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -274,6 +274,10 @@
 
         <lang.inspectionSuppressor language="JAVA" implementationClass="com.demonwav.mcdev.platform.mixin.inspections.ShadowNullabilityInspectionSuppressor"/>
 
+        <runConfigurationExtension implementation="com.demonwav.mcdev.platform.mixin.debug.MixinRunConfigurationExtension"/>
+        <debugger.positionManagerFactory implementation="com.demonwav.mcdev.platform.mixin.debug.MixinPositionManagerFactory"/>
+        <debuggerClassFilterProvider implementation="com.demonwav.mcdev.platform.mixin.debug.MixinDebuggerClassFilterProvider"/>
+        
         <!-- Not ready -->
         <!--<toolWindow id="Minecraft" icon="/assets/icons/platform/Minecraft.png" anchor="right" factoryClass="com.demonwav.mcdev.toolwindow.MinecraftToolWindowFactory"/>-->
     </extensions>


### PR DESCRIPTION
Adds support for debugging Mixins the same way you can debug regular Java classes. See https://github.com/SpongePowered/Mixin/pull/155 for an explanation of how it works.

![](https://cloud.githubusercontent.com/assets/3035868/21239880/1e60ac5c-c309-11e6-9288-c75929e87109.png)

You will still not see the invocation of the injector while debugging, however you can step in the Mixin injector and/or set a breakpoint in a Mixin method.

### Implementation
There are 3 parts that implement the Mixin debugging support for IntelliJ IDEA:

- `MixinRunConfigurationExtension`: Automatically adds the Mixin option (`-Dmixin.sourceDebugExtension=true`) to the VM args when debugging a Mixin module.
- `MixinPositionManager`: Parses the `SourceDebugExtension` added by Mixin and returns the correct Mixin source file while debugging. It will also redirect all breakpoints to the target class so they will work at runtime.
- `MixinDebuggerClassFilterProvider`: Excludes `CallbackInfo` classes from the debugger. Since you don't see the invocation of the injector you need to use Step Into where you expect it to be, the constructor of `CallbackInfo` was just an additional confusing source it jumps to before going to the injector.