### PR TITLE
Add Mixin @Shadow and @Overwrite code assistance

### DIFF
--- a/src/main/java/com/demonwav/mcdev/platform/mixin/inspections/StaticMixinMemberInspection.java
+++ b/src/main/java/com/demonwav/mcdev/platform/mixin/inspections/StaticMixinMemberInspection.java
@@ -87,15 +87,16 @@ public class StaticMixinMemberInspection extends BaseInspection {
                     return false;
                 }
 
-                final PsiModifierList modifierList = mixin.getModifierList();
+                final PsiModifierList modifierList = member.getModifierList();
 
                 if (modifierList == null) {
                     return false;
                 }
 
                 final boolean isOverwrite = member instanceof PsiMethod && McPsiUtil.getAnnotation(member, MixinConstants.Annotations.OVERWRITE) != null;
+                final boolean isShadow = modifierList.findAnnotation(MixinConstants.Annotations.SHADOW) != null;
 
-                return !isOverwrite && member.hasModifierProperty(PsiModifier.PUBLIC) && member.hasModifierProperty(PsiModifier.STATIC);
+                return !isOverwrite && !isShadow && member.hasModifierProperty(PsiModifier.PUBLIC) && member.hasModifierProperty(PsiModifier.STATIC);
             }
         };
     }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/GenerateOverwriteAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/GenerateOverwriteAction.kt
@@ -1,0 +1,113 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.actions
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants
+import com.demonwav.mcdev.platform.mixin.util.MixinUtils
+import com.demonwav.mcdev.platform.mixin.util.findMethods
+import com.demonwav.mcdev.platform.mixin.util.findSource
+import com.demonwav.mcdev.util.MinecraftFileTemplateGroupFactory.Companion.MIXIN_OVERWRITE_FALLBACK
+import com.demonwav.mcdev.util.getClassOfElement
+import com.demonwav.mcdev.util.toTypedArray
+import com.intellij.codeInsight.generation.GenerateMembersUtil
+import com.intellij.codeInsight.generation.OverrideImplementUtil
+import com.intellij.codeInsight.generation.PsiGenerationInfo
+import com.intellij.codeInsight.generation.PsiMethodMember
+import com.intellij.codeInsight.hint.HintManager
+import com.intellij.ide.fileTemplates.FileTemplateManager
+import com.intellij.ide.util.MemberChooser
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.codeStyle.CodeStyleManager
+
+class GenerateOverwriteAction : MixinCodeInsightAction() {
+
+    override fun invoke(project: Project, editor: Editor, file: PsiFile) {
+        val offset = editor.caretModel.offset
+        val psiClass = getClassOfElement(file.findElementAt(offset)) ?: return
+        val methods = (findMethods(psiClass, MixinUtils.getAllMixedClasses(psiClass).values) ?: return)
+                .map(::PsiMethodMember).toTypedArray()
+
+        if (methods.isEmpty()) {
+            HintManager.getInstance().showErrorHint(editor, "No methods to overwrite have been found")
+            return
+        }
+
+        val chooser = MemberChooser<PsiMethodMember>(methods, false, true, project)
+        chooser.title = "Select Methods to Overwrite"
+        chooser.setCopyJavadocVisible(false)
+        chooser.show()
+
+        val elements = chooser.selectedElements ?: return
+        if (elements.isEmpty()) {
+            return
+        }
+
+        runWriteAction {
+            val requiredMembers = LinkedHashSet<PsiMember>()
+
+            val newMethods = elements.map {
+                val method = it.element.findSource()
+                val sourceClass = method.containingClass
+                val codeBlock = method.body
+
+                val newMethod: PsiMethod
+                if (sourceClass != null && codeBlock != null) {
+                    // Source of method is available
+
+                    // Collect all references to potential @Shadow members
+                    requiredMembers.addAll(collectRequiredMembers(codeBlock, sourceClass))
+                }
+
+                // Create temporary (dummy) method
+                var tmpMethod = JavaPsiFacade.getElementFactory(project).createMethod(method.name, method.returnType!!, psiClass)
+
+                // Replace temporary method with a copy of the original method
+                tmpMethod = tmpMethod.replace(method) as PsiMethod
+
+                // Remove Javadocs
+                OverrideImplementUtil.deleteDocComment(tmpMethod)
+
+                // Reformat the code with the project settings
+                newMethod = CodeStyleManager.getInstance(project).reformat(tmpMethod) as PsiMethod
+
+                if (codeBlock == null) {
+                    // Generate fallback method body if source is not available
+                    OverrideImplementUtil.setupMethodBody(newMethod, method, psiClass,
+                            FileTemplateManager.getInstance(project).getCodeTemplate(MIXIN_OVERWRITE_FALLBACK))
+                }
+
+                // TODO: Automatically add Javadoc comment for @Overwrite?
+
+                // Add @Overwrite annotation
+                newMethod.modifierList.addAnnotation(MixinConstants.Annotations.OVERWRITE)
+                PsiGenerationInfo(newMethod)
+            }
+
+            // Generate needed shadows
+            val newShadows = createShadowMembers(project, psiClass, filterNewShadows(requiredMembers, psiClass))
+
+            // Insert new methods
+            GenerateMembersUtil.insertMembersAtOffset(file, offset, newMethods)
+                    // Select first element in editor
+                    .first().positionCaret(editor, true)
+
+            // Insert shadows
+            insertShadows(psiClass, newShadows)
+        }
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/GenerateShadowAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/GenerateShadowAction.kt
@@ -1,0 +1,213 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.actions
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants
+import com.demonwav.mcdev.platform.mixin.util.MixinUtils
+import com.demonwav.mcdev.platform.mixin.util.findFields
+import com.demonwav.mcdev.platform.mixin.util.findMethods
+import com.demonwav.mcdev.util.findChild
+import com.demonwav.mcdev.util.findLastChild
+import com.demonwav.mcdev.util.findSibling
+import com.demonwav.mcdev.util.getClassOfElement
+import com.demonwav.mcdev.util.toTypedArray
+import com.intellij.codeInsight.generation.GenerateMembersUtil
+import com.intellij.codeInsight.generation.GenerationInfo
+import com.intellij.codeInsight.generation.OverrideImplementUtil
+import com.intellij.codeInsight.generation.OverrideImplementsAnnotationsHandler
+import com.intellij.codeInsight.generation.PsiElementClassMember
+import com.intellij.codeInsight.generation.PsiFieldMember
+import com.intellij.codeInsight.generation.PsiGenerationInfo
+import com.intellij.codeInsight.generation.PsiMethodMember
+import com.intellij.codeInsight.hint.HintManager
+import com.intellij.ide.util.MemberChooser
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.extensions.Extensions
+import com.intellij.openapi.project.Project
+import com.intellij.psi.CommonClassNames
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiModifierList
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiSubstitutor
+import java.util.stream.Stream
+import kotlin.streams.toList
+
+class GenerateShadowAction : MixinCodeInsightAction() {
+
+    override fun invoke(project: Project, editor: Editor, file: PsiFile) {
+        val offset = editor.caretModel.offset
+        val psiClass = getClassOfElement(file.findElementAt(offset)) ?: return
+        val targets = MixinUtils.getAllMixedClasses(psiClass).values
+
+        val fields = (findFields(psiClass, targets) ?: Stream.empty())
+                .map(::PsiFieldMember)
+
+        val methods = (findMethods(psiClass, targets) ?: Stream.empty())
+                .map(::PsiMethodMember)
+
+        val members = Stream.concat(fields, methods).toTypedArray()
+
+        if (members.isEmpty()) {
+            HintManager.getInstance().showErrorHint(editor, "No members to shadow have been found")
+            return
+        }
+
+        val chooser = MemberChooser<PsiElementClassMember<*>>(members, false, true, project)
+        chooser.title = "Select members to Shadow"
+        chooser.setCopyJavadocVisible(false)
+        chooser.show()
+
+        val elements = chooser.selectedElements ?: return
+        if (elements.isEmpty()) {
+            return
+        }
+
+        runWriteAction {
+            GenerateMembersUtil.insertMembersAtOffset(file, offset, createShadowMembers(project, psiClass,
+                    elements.stream().map(PsiElementClassMember<*>::getElement)))
+
+                    // Select first element in editor
+                    .firstOrNull()?.positionCaret(editor, false)
+        }
+    }
+
+}
+
+internal fun insertShadows(project: Project, psiClass: PsiClass, members: Stream<PsiMember>) {
+    insertShadows(psiClass, createShadowMembers(project, psiClass, members))
+}
+
+internal fun insertShadows(psiClass: PsiClass, shadows: List<GenerationInfo>) {
+    // Find first element after shadow
+    val lastShadow = findLastChild(psiClass, {
+        (it as? PsiModifierListOwner)?.modifierList?.findAnnotation(MixinConstants.Annotations.SHADOW) != null
+    })
+
+    val anchor: PsiMember?
+
+    if (lastShadow != null) {
+        anchor = findSibling(lastShadow.nextSibling)
+    } else {
+        anchor = findChild(psiClass)
+    }
+
+    // Insert new shadows after last shadow (or at the top of the class)
+    GenerateMembersUtil.insertMembersBeforeAnchor(psiClass, anchor, shadows)
+}
+
+internal fun createShadowMembers(project: Project, psiClass: PsiClass, members: Stream<PsiMember>): List<PsiGenerationInfo<PsiMember>> {
+    var methodAdded = false
+
+    val result = members.map { m ->
+        val shadowMember: PsiMember = when (m) {
+            is PsiMethod -> {
+                methodAdded = true
+                shadowMethod(project, psiClass, m)
+            }
+            is PsiField -> shadowField(project, m)
+            else -> throw UnsupportedOperationException("Unsupported member type: ${m.javaClass.name}")
+        }
+
+        // Add @Shadow annotation
+        shadowMember.modifierList!!.addAnnotation(MixinConstants.Annotations.SHADOW)
+
+        PsiGenerationInfo(shadowMember)
+    }.toList()
+
+    // Make the class abstract (if not already)
+    if (methodAdded && !psiClass.hasModifierProperty(PsiModifier.ABSTRACT)) {
+        psiClass.modifierList!!.setModifierProperty(PsiModifier.ABSTRACT, true)
+    }
+
+    return result
+}
+
+private fun shadowMethod(project: Project, psiClass: PsiClass, method: PsiMethod): PsiMethod {
+    val newMethod = GenerateMembersUtil.substituteGenericMethod(method, PsiSubstitutor.EMPTY, psiClass)
+
+    // Remove Javadocs
+    OverrideImplementUtil.deleteDocComment(newMethod)
+
+    val newModifiers = newMethod.modifierList
+
+    // Relevant modifiers are copied by GenerateMembersUtil.substituteGenericMethod
+
+    // Copy annotations
+    copyAnnotations(project, method.modifierList, newModifiers)
+
+    // If the method was original private, make it protected now
+    if (newModifiers.hasModifierProperty(PsiModifier.PRIVATE)) {
+        newModifiers.setModifierProperty(PsiModifier.PROTECTED, true)
+    }
+
+    // Make method abstract
+    newModifiers.setModifierProperty(PsiModifier.ABSTRACT, true)
+
+    // Remove code block
+    newMethod.body?.delete()
+
+    return newMethod
+}
+
+private fun shadowField(project: Project, field: PsiField): PsiField {
+    val newField = JavaPsiFacade.getElementFactory(project).createField(field.name!!, field.type)
+    val newModifiers = newField.modifierList!!
+
+    val modifiers = field.modifierList!!
+
+    // Copy modifiers
+    copyModifiers(modifiers, newModifiers)
+
+    // Copy annotations
+    copyAnnotations(project, modifiers, newModifiers)
+
+    if (newModifiers.hasModifierProperty(PsiModifier.FINAL)) {
+        // If original field was final, add the @Final annotation instead
+        newModifiers.setModifierProperty(PsiModifier.FINAL, false)
+        newModifiers.addAnnotation(MixinConstants.Annotations.FINAL)
+    }
+
+    return newField
+}
+
+private fun copyModifiers(modifiers: PsiModifierList, newModifiers: PsiModifierList) {
+    for (modifier in PsiModifier.MODIFIERS) {
+        if (modifiers.hasExplicitModifier(modifier)) {
+            newModifiers.setModifierProperty(modifier, true)
+        }
+    }
+}
+
+private fun copyAnnotations(project: Project, modifiers: PsiModifierList, newModifiers: PsiModifierList) {
+    // Copy annotations registered by extensions (e.g. @Nullable), based on OverrideImplementUtil.annotateOnOverrideImplement
+    for (ext in Extensions.getExtensions(OverrideImplementsAnnotationsHandler.EP_NAME)) {
+        for (annotation in ext.getAnnotations(project)) {
+            copyAnnotation(modifiers, newModifiers, annotation)
+        }
+    }
+
+    // Copy @Deprecated annotation
+    copyAnnotation(modifiers, newModifiers, CommonClassNames.JAVA_LANG_DEPRECATED)
+}
+
+private fun copyAnnotation(modifiers: PsiModifierList, newModifiers: PsiModifierList, annotation: String) {
+    // Check if annotation exists
+    val psiAnnotation = modifiers.findAnnotation(annotation) ?: return
+    // Have we already added this annotation? If not, copy it
+    newModifiers.findAnnotation(annotation) ?: newModifiers.addAfter(psiAnnotation, null)
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/MixinCodeInsightAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/MixinCodeInsightAction.kt
@@ -1,0 +1,34 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.actions
+
+import com.demonwav.mcdev.platform.mixin.util.MixinUtils
+import com.intellij.codeInsight.actions.SimpleCodeInsightAction
+import com.intellij.lang.java.JavaLanguage
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+
+abstract class MixinCodeInsightAction : SimpleCodeInsightAction() {
+
+    override fun startInWriteAction() = false
+
+    // Display action in Mixin classes only
+    override fun isValidForFile(project: Project, editor: Editor, file: PsiFile): Boolean {
+        if (file.language != JavaLanguage.INSTANCE) {
+            return false
+        }
+
+        val element = file.findElementAt(editor.caretModel.offset) ?: return false
+        return MixinUtils.getContainingMixinClass(element) != null
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/ShadowReferences.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/ShadowReferences.kt
@@ -1,0 +1,62 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.actions
+
+import com.demonwav.mcdev.platform.mixin.util.findField
+import com.demonwav.mcdev.platform.mixin.util.findMethods
+import com.demonwav.mcdev.platform.mixin.util.memberReference
+import com.intellij.psi.JavaRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiJavaCodeReferenceElement
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiMethod
+import com.intellij.util.containers.isEmpty
+import java.util.stream.Stream
+
+internal fun collectRequiredMembers(element: PsiElement, psiClass: PsiClass): List<PsiMember> {
+    val visitor = CollectRequiredClassMembersVisitor(psiClass)
+    element.accept(visitor)
+    return visitor.members
+}
+
+private class CollectRequiredClassMembersVisitor(private val psiClass: PsiClass) : JavaRecursiveElementWalkingVisitor() {
+
+    internal val members = ArrayList<PsiMember>()
+
+    override fun visitReferenceElement(reference: PsiJavaCodeReferenceElement) {
+        val resolved = reference.advancedResolve(false).element as? PsiMember ?: return
+        if (resolved !is PsiMethod && resolved !is PsiField) {
+            return
+        }
+
+        val resolvedOwner = resolved.containingClass ?: return
+
+        if (psiClass.isEquivalentTo(resolvedOwner)) {
+            // Reference points to the owning class
+            members.add(resolved)
+        }
+
+        super.visitReferenceElement(reference)
+    }
+
+}
+
+internal fun filterNewShadows(requiredMembers: Collection<PsiMember>, psiClass: PsiClass): Stream<PsiMember> {
+    return requiredMembers.stream().filter { m ->
+        when(m) {
+            is PsiMethod -> psiClass.findMethods(m.memberReference).isEmpty()
+            is PsiField -> psiClass.findField(m.memberReference) == null
+            else -> throw UnsupportedOperationException("Unsupported member type: ${m.javaClass.name}")
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/completion/MixinCompletionContributor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/completion/MixinCompletionContributor.kt
@@ -1,0 +1,87 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.completion
+
+import com.demonwav.mcdev.platform.mixin.util.MixinUtils
+import com.demonwav.mcdev.platform.mixin.util.findFields
+import com.demonwav.mcdev.platform.mixin.util.findMethods
+import com.demonwav.mcdev.util.filter
+import com.demonwav.mcdev.util.getClassOfElement
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.codeInsight.completion.JavaCompletionContributor
+import com.intellij.codeInsight.completion.JavaCompletionSorting
+import com.intellij.codeInsight.completion.LegacyCompletionContributor
+import com.intellij.codeInsight.completion.PrioritizedLookupElement
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiJavaReference
+import com.intellij.psi.PsiQualifiedReference
+import java.util.stream.Stream
+
+class MixinCompletionContributor : CompletionContributor() {
+
+    override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
+        if (parameters.completionType != CompletionType.BASIC) {
+            return
+        }
+
+        val position = parameters.position
+        if (!JavaCompletionContributor.isInJavaContext(position)) {
+            return
+        }
+
+        // Check if completing inside Mixin class
+        val psiClass = getClassOfElement(position) ?: return
+        val targets = MixinUtils.getAllMixedClasses(psiClass).values
+        if (targets.isEmpty()) {
+            return
+        }
+
+        val javaResult = JavaCompletionSorting.addJavaSorting(parameters, result)
+
+        val targetType = JavaPsiFacade.getElementFactory(psiClass.project).createType(psiClass)
+        val filter = JavaCompletionContributor.getReferenceFilter(position)
+        val prefixMatcher = result.prefixMatcher
+        LegacyCompletionContributor.processReferences(parameters, javaResult, { reference, result ->
+            if (reference !is PsiJavaReference) {
+                // Only process references to Java elements
+                return@processReferences
+            }
+
+            // Check if referenced element is our Mixin class
+            val qualified = if (reference is PsiQualifiedReference && reference.qualifier != null) {
+                val qualifierExpression = reference.qualifier as? PsiExpression ?: return@processReferences
+                val type = qualifierExpression.type ?: return@processReferences
+                if (type != targetType) {
+                    return@processReferences
+                }
+
+                true
+            } else {
+                false
+            }
+
+            // Process methods and fields from target class
+            Stream.concat(
+                    findMethods(psiClass, targets, checkBases = true)?.map(::MixinMethodLookupItem) ?: Stream.empty<LookupElement>(),
+                    findFields(psiClass, targets, checkBases = true)?.map({ MixinFieldLookupItem(it, qualified) }) ?: Stream.empty<LookupElement>())
+                    .filter(prefixMatcher::prefixMatches)
+                    .filter(filter, position)
+                    .map { PrioritizedLookupElement.withExplicitProximity(it, 1) }
+                    .forEach(result::addElement)
+        })
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/completion/MixinLookupItem.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/completion/MixinLookupItem.kt
@@ -1,0 +1,54 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.completion
+
+import com.demonwav.mcdev.platform.mixin.actions.insertShadows
+import com.demonwav.mcdev.util.getClassOfElement
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.completion.JavaMethodCallElement
+import com.intellij.codeInsight.lookup.VariableLookupItem
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.impl.source.PostprocessReformattingAspect
+import java.util.stream.Stream
+
+internal class MixinMethodLookupItem(method: PsiMethod) : JavaMethodCallElement(method) {
+
+    override fun handleInsert(context: InsertionContext) {
+        insertShadow(context, `object`)
+        super.handleInsert(context)
+    }
+
+}
+
+internal class MixinFieldLookupItem(field: PsiField, private val qualified: Boolean) : VariableLookupItem(field) {
+
+    override fun handleInsert(context: InsertionContext) {
+        insertShadow(context, `object` as PsiMember)
+
+        if (this.qualified) {
+            super.handleInsert(context)
+        } else {
+            // Cannot call super because that would add a qualifier to the target class
+            context.document.replaceString(context.startOffset, context.tailOffset, `object`.name!!)
+            context.commitDocument()
+        }
+    }
+
+}
+
+private fun insertShadow(context: InsertionContext, member: PsiMember) {
+    // Insert @Shadow element
+    val psiClass = getClassOfElement(context.file.findElementAt(context.startOffset)) ?: return
+    insertShadows(context.project, psiClass, Stream.of(member))
+    PostprocessReformattingAspect.getInstance(context.project).doPostponedFormatting()
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/editor/MixinCopyPasteReferenceProcessor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/editor/MixinCopyPasteReferenceProcessor.kt
@@ -1,0 +1,158 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.editor
+
+import com.demonwav.mcdev.platform.mixin.actions.insertShadows
+import com.demonwav.mcdev.platform.mixin.util.MixinUtils
+import com.demonwav.mcdev.platform.mixin.util.findField
+import com.demonwav.mcdev.platform.mixin.util.findMethods
+import com.demonwav.mcdev.platform.mixin.util.qualifiedMemberReference
+import com.demonwav.mcdev.util.findParent
+import com.demonwav.mcdev.util.getClassOfElement
+import com.intellij.codeInsight.editorActions.JavaCopyPasteReferenceProcessor
+import com.intellij.codeInsight.editorActions.ReferenceData
+import com.intellij.openapi.editor.RangeMarker
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiJavaCodeReferenceElement
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiMethod
+import com.intellij.util.containers.isEmpty
+import java.util.ArrayList
+
+/**
+ * Automatically creates @Shadows for the referenced field and methods when
+ * copying from a target class.
+ */
+class MixinCopyPasteReferenceProcessor : JavaCopyPasteReferenceProcessor() {
+
+    override fun addReferenceData(file: PsiFile, startOffset: Int, element: PsiElement, to: ArrayList<ReferenceData>) {
+        super.addReferenceData(file, startOffset, element, to)
+
+        val reference = element as? PsiJavaCodeReferenceElement ?: return
+        val resolved = reference.advancedResolve(false).element as? PsiMember ?: return
+
+        val member = when (resolved) {
+            is PsiMethod -> {
+                if (resolved.isConstructor) {
+                    return
+                }
+
+                resolved.qualifiedMemberReference
+            }
+            is PsiField -> resolved.qualifiedMemberReference
+            else -> return
+        }
+
+        to.add(MixinReferenceData.create(element, startOffset, member))
+    }
+
+    override fun findReferencesToRestore(file: PsiFile, bounds: RangeMarker, referenceData: Array<out ReferenceData>)
+            : Array<PsiJavaCodeReferenceElement?> {
+        val refs = super.findReferencesToRestore(file, bounds, referenceData)
+
+        // Check if pasting to Mixin class
+        val elementInTargetClass = file.findElementAt(bounds.startOffset) ?: return refs
+        val psiClass = getClassOfElement(elementInTargetClass) ?: return refs
+
+        val targets = MixinUtils.getAllMixedClasses(psiClass).values
+        if (targets.isEmpty()) {
+            // Not a Mixin, so there is no need to add @Shadow members
+            return refs
+        }
+
+        val targetNames = targets.mapNotNull { it.qualifiedName }
+
+        for ((i, data) in referenceData.withIndex()) {
+            if (data !is MixinReferenceData || data.qClassName !in targetNames) {
+                continue
+            }
+
+            val startOffset = data.startOffset + bounds.startOffset
+
+            val element = file.findElementAt(startOffset) ?: continue
+            val reference = findParent<PsiJavaCodeReferenceElement>(element) ?: continue
+
+            val endOffset = data.endOffset + bounds.startOffset
+
+            if (!reference.textRange.equalsToRange(startOffset, endOffset)) {
+                continue
+            }
+
+            // Check if reference already exists in Mixin class
+            val name = data.staticMemberName!!
+            if ('(' in name) {
+                // Check if method does not already exist in target class
+                if (!psiClass.findMethods(data.reference).isEmpty()) {
+                    continue
+                }
+            } else {
+                // Field
+                if (psiClass.findField(data.reference) != null) {
+                    continue
+                }
+            }
+
+            refs[i] = reference
+        }
+
+        return refs
+    }
+
+    override fun restoreReferences(referenceData: Array<out ReferenceData>, refs: Array<PsiJavaCodeReferenceElement?>) {
+        val members = ArrayList<PsiMember>()
+
+        var psiClass: PsiClass? = null
+
+        for ((i, data) in referenceData.withIndex()) {
+            val reference = refs[i] ?: continue
+
+            if (data !is MixinReferenceData) {
+                continue
+            }
+
+            try {
+                // Store Mixin class so we can use it later
+                if (psiClass == null) {
+                    psiClass = (getClassOfElement(reference) ?: return)
+                }
+
+                // Lookup target class
+                val targetClass = JavaPsiFacade.getInstance(psiClass.project).findClass(data.qClassName, reference.resolveScope) ?: continue
+
+                val name = data.staticMemberName!!
+
+                if ('(' in name) {
+                    // Add target method
+                    val targetMethod = targetClass.findMethods(data.reference).findAny().orElse(null) ?: continue
+                    members.add(targetMethod)
+                } else {
+                    // Add target field
+                    val targetField = targetClass.findField(data.reference) ?: continue
+                    members.add(targetField)
+                }
+            } finally {
+                refs[i] = null
+            }
+        }
+
+        // Create @Shadows
+        if (psiClass != null) {
+            insertShadows(psiClass.project, psiClass, members.stream())
+        }
+
+        super.restoreReferences(referenceData, refs)
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/editor/MixinReferenceData.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/editor/MixinReferenceData.kt
@@ -1,0 +1,32 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.editor
+
+import com.demonwav.mcdev.platform.mixin.util.MemberReference
+import com.intellij.codeInsight.editorActions.ReferenceData
+import com.intellij.psi.PsiElement
+
+internal class MixinReferenceData(startOffset: Int, endOffset: Int, internal val reference: MemberReference)
+    : ReferenceData(startOffset, endOffset, reference.owner!!, reference.name) {
+
+    internal companion object {
+
+        internal fun create(element: PsiElement, startOffset: Int, reference: MemberReference): MixinReferenceData {
+            val range = element.textRange
+            return MixinReferenceData(
+                    range.startOffset - startOffset,
+                    range.endOffset - startOffset,
+                    reference)
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/insight/OverwriteLineMarker.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/insight/OverwriteLineMarker.kt
@@ -1,0 +1,79 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.insight
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants
+import com.demonwav.mcdev.platform.mixin.util.MixinUtils
+import com.demonwav.mcdev.platform.mixin.util.findMethods
+import com.demonwav.mcdev.platform.mixin.util.memberReference
+import com.demonwav.mcdev.util.getClassOfElement
+import com.demonwav.mcdev.util.toTypedArray
+import com.intellij.codeHighlighting.Pass
+import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProviderDescriptor
+import com.intellij.codeInsight.daemon.MergeableLineMarkerInfo
+import com.intellij.codeInsight.daemon.impl.PsiElementListNavigator
+import com.intellij.icons.AllIcons
+import com.intellij.ide.util.MethodCellRenderer
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiIdentifier
+import com.intellij.psi.PsiMethod
+import com.intellij.util.FunctionUtil
+import java.awt.event.MouseEvent
+import javax.swing.Icon
+
+class OverwriteLineMarkerProvider : LineMarkerProviderDescriptor(), GutterIconNavigationHandler<PsiIdentifier> {
+
+    override fun getName() = "Mixin @Overwrite line marker"
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<PsiIdentifier>? {
+        val method = element as? PsiMethod ?: return null
+        val identifier = method.nameIdentifier ?: return null
+        return if (method.modifierList.findAnnotation(MixinConstants.Annotations.OVERWRITE) != null) {
+            OverwriteLineMarker(identifier, this)
+        } else {
+            null
+        }
+    }
+
+    override fun collectSlowLineMarkers(elements: List<PsiElement>, result: Collection<LineMarkerInfo<PsiElement>>) {
+    }
+
+    override fun navigate(e: MouseEvent, elt: PsiIdentifier) {
+        val method = elt.parent as? PsiMethod ?: return
+        val psiClass = getClassOfElement(method) ?: return
+
+        val reference = method.memberReference
+        val targetMethods = MixinUtils.getAllMixedClasses(psiClass).values.stream()
+                .flatMap { it.findMethods(reference) }
+                .toTypedArray()
+        PsiElementListNavigator.openTargets(e, targetMethods,
+                "Choose target method of ${method.name}", null, MethodCellRenderer(false))
+    }
+
+}
+
+private class OverwriteLineMarker(identifier: PsiIdentifier, navHandler: GutterIconNavigationHandler<PsiIdentifier>)
+    : MergeableLineMarkerInfo<PsiIdentifier>(identifier, identifier.textRange, AllIcons.Gutter.OverridingMethod,
+        Pass.LINE_MARKERS, TOOLTIP_FUNCTION, navHandler, GutterIconRenderer.Alignment.LEFT) {
+
+    override fun canMergeWith(info: MergeableLineMarkerInfo<*>) = info is OverwriteLineMarker
+    override fun getCommonTooltip(infos: MutableList<MergeableLineMarkerInfo<PsiElement>>) = TOOLTIP_FUNCTION
+    override fun getCommonIcon(infos: List<MergeableLineMarkerInfo<PsiElement>>) = ICON
+
+    private companion object {
+        @JvmField val ICON: Icon = AllIcons.Gutter.OverridingMethod
+        @JvmField val TOOLTIP_FUNCTION = FunctionUtil.constant<Any, String>("Go to target method")
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/OverwriteInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/OverwriteInspection.kt
@@ -1,0 +1,66 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants
+import com.demonwav.mcdev.platform.mixin.util.MixinUtils
+import com.demonwav.mcdev.platform.mixin.util.findMethods
+import com.demonwav.mcdev.platform.mixin.util.memberReference
+import com.demonwav.mcdev.util.getClassOfElement
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiMethod
+
+class OverwriteInspection : MixinInspection() {
+
+    override fun getStaticDescription() = "Reports related to Mixin @Overwrites"
+
+    override fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor = Visitor(holder)
+
+    private class Visitor(private val holder: ProblemsHolder) : JavaElementVisitor() {
+
+        override fun visitMethod(method: PsiMethod) {
+            val modifiers = method.modifierList
+
+            // Check if the method is an @Overwrite
+            modifiers.findAnnotation(MixinConstants.Annotations.OVERWRITE) ?: return
+
+            val identifier = method.nameIdentifier ?: return
+
+            val psiClass = getClassOfElement(method) ?: return
+            val targets = MixinUtils.getAllMixedClasses(psiClass).values
+            if (targets.isEmpty()) {
+                return
+            }
+
+            val memberReference = method.memberReference
+
+            val resolved = when (targets.size) {
+                0 -> return
+                1 -> targets.single().findMethods(memberReference).findAny().orElse(null)
+                else ->
+                    // TODO: Improve detection of valid target methods in Mixins with multiple targets
+                    targets.stream()
+                            .flatMap { it.findMethods(memberReference) }
+                            .findAny().orElse(null)
+
+            }
+
+            if (resolved == null) {
+                holder.registerProblem(identifier, "Cannot resolve method '${method.name}' in target class")
+            }
+
+            // TODO: Verify method modifiers?
+        }
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/McPsiUtil.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/McPsiUtil.kt
@@ -27,10 +27,12 @@ import com.intellij.psi.PsiMember
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiModifierListOwner
 import com.intellij.psi.PsiReference
+import com.intellij.psi.filters.ElementFilter
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.annotations.Contract
 import java.util.Collections
 import java.util.stream.Collectors
+import java.util.stream.Stream
 
 @JvmOverloads
 @Contract(value = "null, _ -> null", pure = true)
@@ -188,4 +190,9 @@ fun getNameOfClass(psiClass: PsiClass?): Pair<String, PsiClass>? {
     Collections.reverse(innerStrings)
     // Skip the base class, we are giving the base PsiClass so the user can do with it what they want
     return Pair.create("$" + innerStrings.stream().skip(1).collect(Collectors.joining("$")), baseClass)
+}
+
+internal fun <T : Any> Stream<T>.filter(filter: ElementFilter?, context: PsiElement): Stream<T> {
+    filter ?: return this
+    return filter { filter.isClassAcceptable(it.javaClass) && filter.isAcceptable(it, context) }
 }

--- a/src/main/kotlin/com/demonwav/mcdev/util/MinecraftFileTemplateGroupFactory.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/MinecraftFileTemplateGroupFactory.kt
@@ -56,6 +56,8 @@ class MinecraftFileTemplateGroupFactory : FileTemplateGroupDescriptorFactory {
         group.addTemplate(FileTemplateDescriptor(CANARY_INF_TEMPLATE, PlatformAssets.CANARY_ICON))
         group.addTemplate(FileTemplateDescriptor(CANARY_POM_TEMPLATE, PlatformAssets.CANARY_ICON))
 
+        group.addTemplate(FileTemplateDescriptor(MIXIN_OVERWRITE_FALLBACK, PlatformAssets.MIXIN_ICON))
+
         return group
     }
 
@@ -94,6 +96,8 @@ class MinecraftFileTemplateGroupFactory : FileTemplateGroupDescriptorFactory {
         const val CANARY_MAIN_CLASS_TEMPLATE = "canary_main_class.java"
         const val CANARY_INF_TEMPLATE = "canary_plugin_description_file.inf"
         const val CANARY_POM_TEMPLATE = "canary_pom_template.xml"
+
+        const val MIXIN_OVERWRITE_FALLBACK = "Mixin Overwrite Fallback.java"
     }
 
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -68,6 +68,9 @@
         <externalProjectDataService implementation="com.demonwav.mcdev.platform.mixin.gradle.MixinDataService"/>
         <externalProjectDataService implementation="com.demonwav.mcdev.platform.mcp.gradle.McpDataService"/>
 
+        <completion.contributor language="JAVA" implementationClass="com.demonwav.mcdev.platform.mixin.completion.MixinCompletionContributor"
+                                order="last, before javaLegacy"/>
+
         <!-- Project-independent Line Marker Providers -->
         <codeInsight.lineMarkerProvider language="" implementationClass="com.demonwav.mcdev.insight.ListenerLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="" implementationClass="com.demonwav.mcdev.insight.ColorLineMarkerProvider"/>
@@ -79,6 +82,9 @@
         <!-- Mixin Line Marker Providers -->
         <codeInsight.lineMarkerProvider language="JAVA" implementationClass="com.demonwav.mcdev.platform.mixin.insight.MixinLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="JAVA" implementationClass="com.demonwav.mcdev.platform.mixin.insight.ShadowLineMarkerProvider"/>
+        <codeInsight.lineMarkerProvider language="JAVA" implementationClass="com.demonwav.mcdev.platform.mixin.insight.OverwriteLineMarkerProvider"/>
+
+        <copyPastePostProcessor order="first" implementation="com.demonwav.mcdev.platform.mixin.editor.MixinCopyPasteReferenceProcessor"/>
 
         <!-- MCP CFG file type -->
         <fileTypeFactory implementation="com.demonwav.mcdev.platform.mcp.at.AtFileTypeFactory"/>
@@ -257,6 +263,14 @@
                          hasStaticDescription="true"
                          implementationClass="com.demonwav.mcdev.platform.mixin.inspections.FinalInspection"/>
 
+        <localInspection displayName="@Overwrite method target"
+                         groupName="Mixin"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.inspection.OverwriteInspection"/>
+
         <customJavadocTagProvider implementation="com.demonwav.mcdev.platform.mixin.MixinCustomJavaDocTagProvider"/>
 
         <!-- Project View Node Decorators provide the project icons -->
@@ -344,6 +358,16 @@
                 text="Find Mixins"
                 description="Find classes which mix into this class">
             <add-to-group relative-to-action="EditorPopupMenu2" anchor="after" group-id="EditorPopupMenu"/>
+        </action>
+        <action class="com.demonwav.mcdev.platform.mixin.actions.GenerateShadowAction" id="GenerateShadowAction"
+                text="Shadow Members..."
+                description="Add a @Shadow for the selected members">
+            <add-to-group group-id="GenerateGroup" anchor="last" />
+        </action>
+        <action class="com.demonwav.mcdev.platform.mixin.actions.GenerateOverwriteAction" id="GenerateOverwriteAction"
+                text="Overwrite Methods..."
+                description="Add an @Overwrite for the selected methods">
+            <add-to-group group-id="GenerateGroup" anchor="last" />
         </action>
         <action class="com.demonwav.mcdev.platform.mcp.actions.FindSrgMappingAction" id="FindSrgMappingAction"
                 text="Get SRG Name"

--- a/src/main/resources/fileTemplates/code/Mixin Overwrite Fallback.java.ft
+++ b/src/main/resources/fileTemplates/code/Mixin Overwrite Fallback.java.ft
@@ -1,0 +1,3 @@
+// Source of original method is not available#if ( $RETURN_TYPE != "void" )
+
+return $DEFAULT_RETURN_VALUE;#end

--- a/src/main/resources/fileTemplates/code/Mixin Overwrite Fallback.java.html
+++ b/src/main/resources/fileTemplates/code/Mixin Overwrite Fallback.java.html
@@ -1,0 +1,15 @@
+<!--
+    Minecraft Dev for IntelliJ
+
+    https://minecraftdev.org
+
+    Copyright (c) 2017 minecraft-dev
+
+    MIT License
+-->
+
+<html>
+<body>
+<p>This is a built-in file template used when generating an @Overwrite method and the original source is not available.</p>
+</body>
+</html>


### PR DESCRIPTION
Adds additional code assistance for working with Mixin `@Shadow`s and `@Overwrite`s.

**New features:**
- Automatic completion of `@Shadow` members: Members in the target class are available like regular methods/fields in the code completion of the Mixin class. If selected, a @Shadow member will be generated automatically.
- "Generate `@Shadow`" action: Generates a `@Shadow` member for one or multiple selected members in the target class
- "Generate `@Overwrite`" action: Copies the original method source as an `@Overwrite` to the Mixin class and adds all necessary `@Shadow` members
- Improved handling of copy/paste from the target class, will automatically add all necessary `@Shadow` elements when copying code from the target class
- Static member inspection now ignores `@Shadow` members
- Line marker for `@Overwrite` methods to jump to the target method

Short video showing `@Shadow` / `@Overwrite` features:

[![](https://cloud.githubusercontent.com/assets/3035868/21578425/6c0b196a-cf7f-11e6-9d07-969a45dc1478.png)](https://download.minecrell.net/minecraft/sponge/mixin-completion.mp4)

**Note:** This PR targets the `mixin-base` branch so you only see the new changes instead of also all the base classes. #123 is required for this PR.