### PR TITLE
Add Mixin reference completion

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/CopyMixinTargetReferenceAction.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/actions/CopyMixinTargetReferenceAction.kt
@@ -1,0 +1,45 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.actions
+
+import com.demonwav.mcdev.platform.mixin.util.qualifiedMemberReference
+import com.demonwav.mcdev.util.findReferencedMember
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys.CARET
+import com.intellij.openapi.actionSystem.CommonDataKeys.PSI_FILE
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.wm.WindowManager
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import java.awt.datatransfer.StringSelection
+
+class CopyMixinTargetReferenceAction : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val file = e.getData(PSI_FILE) ?: return
+        val caret = e.getData(CARET) ?: return
+
+        val element = file.findElementAt(caret.offset) ?: return
+        val member = findReferencedMember(element) ?: return
+
+        val targetReference = when (member) {
+            is PsiMethod -> member.qualifiedMemberReference
+            is PsiField -> member.qualifiedMemberReference
+            else -> return
+        }
+
+        CopyPasteManager.getInstance().setContents(StringSelection(targetReference.toString()))
+        WindowManager.getInstance().getStatusBar(project).info = "Mixin target reference has been copied."
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/completion/MixinCompletionConfidence.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/completion/MixinCompletionConfidence.kt
@@ -1,0 +1,39 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.completion
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants
+import com.intellij.codeInsight.completion.CompletionConfidence
+import com.intellij.codeInsight.completion.SkipAutopopupInStrings
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.PsiJavaPatterns
+import com.intellij.patterns.StandardPatterns
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.util.ThreeState
+
+class MixinCompletionConfidence : CompletionConfidence() {
+
+    private val mixinAnnotation = PlatformPatterns.psiElement()
+            .inside(false, PsiJavaPatterns.psiAnnotation().qName(StandardPatterns.string().startsWith(MixinConstants.PACKAGE)),
+                    PlatformPatterns.psiFile())!!
+
+    override fun shouldSkipAutopopup(element: PsiElement, psiFile: PsiFile, offset: Int): ThreeState {
+        // Enable auto complete for all string literals which are children of one of the annotations in Mixin
+        // TODO: Make this more reliable (we don't need to enable it for all parts of the annotation)
+        return if (SkipAutopopupInStrings.isInStringLiteral(element) && mixinAnnotation.accepts(element)) {
+            ThreeState.NO
+        } else {
+            ThreeState.UNSURE
+        }
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/AmbiguousReferenceInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/AmbiguousReferenceInspection.kt
@@ -1,0 +1,30 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.reference
+
+import com.demonwav.mcdev.platform.mixin.reference.MethodReference
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.METHOD_INJECTORS
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAnnotationMemberValue
+
+class AmbiguousReferenceInspection : AnnotationAttributeInspection(METHOD_INJECTORS, "method") {
+
+    override fun getStaticDescription() = "Reports ambiguous references in Mixin annotations"
+
+    override fun visitAnnotationAttribute(annotation: PsiAnnotation, value: PsiAnnotationMemberValue, holder: ProblemsHolder) {
+        val ambiguousReference = MethodReference.getReferenceIfAmbiguous(value) ?: return
+
+        // TODO: Quick fix
+        holder.registerProblem(value, "Ambiguous reference to method '${ambiguousReference.name}' in target class")
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/AnnotationAttributeInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/AnnotationAttributeInspection.kt
@@ -1,0 +1,48 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.reference
+
+import com.demonwav.mcdev.platform.mixin.inspection.MixinInspection
+import com.demonwav.mcdev.util.annotationFromNameValuePair
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAnnotationMemberValue
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiNameValuePair
+
+abstract class AnnotationAttributeInspection(private val annotation: List<String>, private val attribute: String) : MixinInspection() {
+
+    constructor(annotation: String, attribute: String) : this(listOf(annotation), attribute)
+
+    protected abstract fun visitAnnotationAttribute(annotation: PsiAnnotation, value: PsiAnnotationMemberValue, holder: ProblemsHolder)
+
+    override final fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor = Visitor(holder)
+
+    private inner class Visitor(private val holder: ProblemsHolder) : JavaElementVisitor() {
+
+        override fun visitNameValuePair(pair: PsiNameValuePair) {
+            if (pair.name != attribute) {
+                return
+            }
+
+            val psiAnnotation = pair.annotationFromNameValuePair ?: return
+            if (psiAnnotation.qualifiedName !in annotation) {
+                return
+            }
+
+            val value = pair.value ?: return
+            visitAnnotationAttribute(psiAnnotation, value, this.holder)
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/InvalidMemberReferenceInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/InvalidMemberReferenceInspection.kt
@@ -1,0 +1,62 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.reference
+
+import com.demonwav.mcdev.platform.mixin.inspection.MixinInspection
+import com.demonwav.mcdev.platform.mixin.reference.MethodReference
+import com.demonwav.mcdev.platform.mixin.reference.MixinReference
+import com.demonwav.mcdev.platform.mixin.reference.target.TargetReference
+import com.demonwav.mcdev.platform.mixin.util.MemberReference
+import com.demonwav.mcdev.util.annotationFromNameValuePair
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiNameValuePair
+
+class InvalidMemberReferenceInspection : MixinInspection() {
+
+    override fun getStaticDescription() = """
+        |Reports invalid usages of member references in Mixin annotations. Two different formats are supported by Mixin:
+        | - Lcom/example/ExampleClass;execute(II)V
+        | - com.example.ExampleClass.execute(II)V
+    """.trimMargin()
+
+    override fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor = Visitor(holder)
+
+    private class Visitor(private val holder: ProblemsHolder) : JavaElementVisitor() {
+
+        override fun visitNameValuePair(pair: PsiNameValuePair) {
+            val name = pair.name ?: return
+
+            val resolver: MixinReference = when (name) {
+                "method" -> MethodReference
+                "target" -> TargetReference
+                else -> return
+            }
+
+            // Check if valid annotation
+            val annotation = pair.annotationFromNameValuePair ?: return
+            if (!resolver.isValidAnnotation(annotation.qualifiedName!!)) {
+                return
+            }
+
+            val value = pair.value ?: return
+
+            // Attempt to parse the reference
+            if (MemberReference.parse(value.constantStringValue) == null) {
+                holder.registerProblem(value, "Invalid member reference")
+            }
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/UnnecessaryQualifiedMemberReferenceInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/UnnecessaryQualifiedMemberReferenceInspection.kt
@@ -1,0 +1,47 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.reference
+
+import com.demonwav.mcdev.platform.mixin.util.MemberReference
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.METHOD_INJECTORS
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAnnotationMemberValue
+
+class UnnecessaryQualifiedMemberReferenceInspection : AnnotationAttributeInspection(METHOD_INJECTORS, "method") {
+
+    override fun getStaticDescription() = "Reports unnecessary qualified member references in @Inject annotations"
+
+    override fun visitAnnotationAttribute(annotation: PsiAnnotation, value: PsiAnnotationMemberValue, holder: ProblemsHolder) {
+        val reference = MemberReference.parse(value.constantStringValue) ?: return
+        if (reference.qualified) {
+            holder.registerProblem(value, "Unnecessary qualified reference to '${reference.name}' in target class", QuickFix(reference))
+        }
+    }
+
+    private class QuickFix(private val reference: MemberReference) : LocalQuickFix {
+
+        override fun getFamilyName() = "Remove qualifier"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val element = descriptor.psiElement
+            element.replace(JavaPsiFacade.getElementFactory(project)
+                    .createExpressionFromText("\"${reference.withoutOwner}\"", element))
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/UnqualifiedMemberReferenceInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/UnqualifiedMemberReferenceInspection.kt
@@ -1,0 +1,44 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.reference
+
+import com.demonwav.mcdev.platform.mixin.reference.target.TargetReference
+import com.demonwav.mcdev.platform.mixin.util.MemberReference
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAnnotationMemberValue
+
+class UnqualifiedMemberReferenceInspection : AnnotationAttributeInspection(AT, "target") {
+
+    override fun getStaticDescription() = "Reports unqualified member references in @At targets"
+
+    override fun visitAnnotationAttribute(annotation: PsiAnnotation, value: PsiAnnotationMemberValue, holder: ProblemsHolder) {
+        // Check if the specified target reference uses member descriptors
+        if (!TargetReference.usesMemberReference(value)) {
+            return
+        }
+
+        // TODO: Quick fix
+
+        val reference = MemberReference.parse(value.constantStringValue) ?: return
+        if (!reference.qualified) {
+            holder.registerProblem(value, "Unqualified member reference in @At target")
+            return
+        }
+
+        if (reference.descriptor == null) {
+            holder.registerProblem(value, "Method/field descriptor is required for member reference in @At target")
+        }
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/UnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/UnresolvedReferenceInspection.kt
@@ -1,0 +1,71 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.reference
+
+import com.demonwav.mcdev.platform.mixin.inspection.MixinInspection
+import com.demonwav.mcdev.platform.mixin.reference.InjectionPointType
+import com.demonwav.mcdev.platform.mixin.reference.MethodReference
+import com.demonwav.mcdev.platform.mixin.reference.MixinReference
+import com.demonwav.mcdev.platform.mixin.reference.target.TargetReference
+import com.demonwav.mcdev.util.annotationFromNameValuePair
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAnnotationMemberValue
+import com.intellij.psi.PsiArrayInitializerMemberValue
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiNameValuePair
+
+class UnresolvedReferenceInspection : MixinInspection() {
+
+    override fun getStaticDescription() = "Reports unresolved references in Mixin annotations"
+
+    override fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor = Visitor(holder)
+
+    private class Visitor(private val holder: ProblemsHolder) : JavaElementVisitor() {
+
+        override fun visitNameValuePair(pair: PsiNameValuePair) {
+            val name = pair.name ?: PsiAnnotation.DEFAULT_REFERENCED_METHOD_NAME
+            val resolver: MixinReference = when (name) {
+                "method" -> MethodReference
+                "target" -> TargetReference
+                "value" -> InjectionPointType
+                else -> return
+            }
+
+            // Check if valid annotation
+            val annotation = pair.annotationFromNameValuePair ?: return
+            if (!resolver.isValidAnnotation(annotation.qualifiedName!!)) {
+                return
+            }
+
+            val value = pair.value ?: return
+            if (value is PsiArrayInitializerMemberValue) {
+                for (initializer in value.initializers) {
+                    checkResolved(resolver, initializer)
+                }
+            } else {
+                checkResolved(resolver, value)
+            }
+        }
+
+        private fun checkResolved(resolver: MixinReference, value: PsiAnnotationMemberValue) {
+            if (resolver.isUnresolved(value)) {
+                holder.registerProblem(value, "Cannot resolve ${resolver.description}".format(value.constantStringValue),
+                        ProblemHighlightType.LIKE_UNKNOWN_SYMBOL)
+            }
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/signature/InjectorType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/signature/InjectorType.kt
@@ -1,0 +1,188 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.signature
+
+import com.demonwav.mcdev.platform.mixin.reference.target.TargetReference
+import com.demonwav.mcdev.platform.mixin.util.MemberReference
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants
+import com.demonwav.mcdev.platform.mixin.util.callbackInfoReturnableType
+import com.demonwav.mcdev.platform.mixin.util.callbackInfoType
+import com.demonwav.mcdev.util.Parameter
+import com.demonwav.mcdev.util.constantStringValue
+import com.demonwav.mcdev.util.constantValue
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAnnotationOwner
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier.STATIC
+import com.intellij.psi.PsiNameHelper
+import com.intellij.psi.PsiQualifiedReference
+import com.intellij.psi.PsiType
+import org.objectweb.asm.Opcodes
+
+internal enum class InjectorType(private val annotation: String) {
+    INJECT(MixinConstants.Annotations.INJECT) {
+
+        override fun expectedMethodSignature(annotation: PsiAnnotation, targetMethod: PsiMethod): MethodSignature? {
+            val returnType = targetMethod.returnType
+
+            val result = ArrayList<ParameterGroup>()
+
+            // Parameters from injected method (optional)
+            result.add(ParameterGroup(collectTargetMethodParameters(targetMethod), required = false, default = true))
+
+            // Callback info (required)
+            result.add(ParameterGroup(listOf(if (returnType == null || returnType == PsiType.VOID) {
+                Parameter("ci", callbackInfoType(targetMethod.project)!!)
+            } else {
+                Parameter("cir", callbackInfoReturnableType(targetMethod.project, targetMethod, returnType)!!)
+            })))
+
+            // Captured locals (only if local capture is enabled)
+            // Right now we allow any parameters here since we can't easily
+            // detect the local variables that can be captured
+            if (((annotation.findDeclaredAttributeValue("locals") as? PsiQualifiedReference)
+                    ?.referenceName ?: "NO_CAPTURE") != "NO_CAPTURE") {
+                result.add(ParameterGroup(null))
+            }
+
+            return MethodSignature(result, PsiType.VOID)
+        }
+
+    },
+    REDIRECT(MixinConstants.Annotations.REDIRECT) {
+
+        override fun expectedMethodSignature(annotation: PsiAnnotation, targetMethod: PsiMethod): MethodSignature? {
+            val at = annotation.findDeclaredAttributeValue("at") as? PsiAnnotation ?: return null
+            val target = at.findDeclaredAttributeValue("target") ?: return null
+
+            if (!TargetReference.usesMemberReference(target)) {
+                return null
+            }
+
+            // Since the target reference is required to be full qualified,
+            // we don't actually have to resolve the target reference in the
+            // target method. Everything needed to get the method parameters
+            // is included in the reference.
+            val reference = MemberReference.parse(target.constantStringValue) ?: return null
+
+            if (!reference.qualified || reference.descriptor == null) {
+                // Invalid anyway and we need the qualified reference
+                return null
+            }
+
+            val (owner, member) = reference.resolve(annotation.project, annotation.resolveScope) ?: return null
+            val (parameters, returnType) = when (member) {
+                is PsiMethod -> collectMethodParameters(owner, member)
+                is PsiField -> collectFieldParameters(at, owner, member)
+                else -> throw AssertionError("Cannot resolve member reference to: $member")
+            } ?: return null
+
+            val primaryGroup = ParameterGroup(parameters, required = true)
+
+            // Optionally the target method parameters can be used
+            val targetMethodGroup = ParameterGroup(collectTargetMethodParameters(targetMethod), required = false)
+
+            return MethodSignature(listOf(primaryGroup, targetMethodGroup), returnType)
+        }
+
+        private fun getInstanceParameter(owner: PsiClass): Parameter {
+            return Parameter(null, JavaPsiFacade.getElementFactory(owner.project).createType(owner))
+        }
+
+        private fun collectMethodParameters(owner: PsiClass, method: PsiMethod): Pair<List<Parameter>, PsiType>? {
+            val parameterList = method.parameterList
+            val parameters = ArrayList<Parameter>(parameterList.parametersCount + 1)
+
+            val returnType = if (method.isConstructor) {
+                PsiType.VOID
+            } else {
+                if (!method.hasModifierProperty(STATIC)) {
+                    parameters.add(getInstanceParameter(owner))
+                }
+
+                method.returnType!!
+            }
+
+            parameterList.parameters.mapTo(parameters, ::Parameter)
+            return Pair(parameters, returnType)
+        }
+
+        private fun collectFieldParameters(at: PsiAnnotation, owner: PsiClass, field: PsiField): Pair<List<Parameter>, PsiType>? {
+            // TODO: Report if opcode isn't set
+            val opcode = at.findDeclaredAttributeValue("opcode")?.constantValue as? Int ?: return null
+
+            // TODO: Report if magic value is used instead of a reference to a field (e.g. to ASM's Opcodes interface)
+            // TODO: Report if opcode is invalid (not one of GETSTATIC, GETFIELD, PUTSTATIC, PUTFIELD)
+
+            val parameters = ArrayList<Parameter>(2)
+
+            // TODO: Report if GETSTATIC/PUTSTATIC is used for an instance field
+            if (opcode == Opcodes.GETFIELD || opcode == Opcodes.PUTFIELD) {
+                parameters.add(getInstanceParameter(owner))
+            }
+
+            val returnType = when (opcode) {
+                Opcodes.GETFIELD, Opcodes.GETSTATIC -> field.type
+                Opcodes.PUTFIELD, Opcodes.PUTSTATIC -> {
+                    parameters.add(Parameter("value", field.type))
+                    PsiType.VOID
+                }
+                else -> return null // Invalid opcode
+            }
+
+            return Pair(parameters, returnType)
+        }
+
+    },
+    MODIFY_ARG(MixinConstants.Annotations.MODIFY_ARG),
+    MODIFY_CONSTANT(MixinConstants.Annotations.MODIFY_CONSTANT),
+    MODIFY_VARIABLE(MixinConstants.Annotations.MODIFY_VARIABLE);
+
+    internal val annotationName = "@${PsiNameHelper.getShortClassName(annotation)}"
+
+    internal open fun expectedMethodSignature(annotation: PsiAnnotation, targetMethod: PsiMethod): MethodSignature? = null
+
+    internal companion object {
+
+        private val injectionPointAnnotations = InjectorType.values().associateBy { it.annotation }
+
+        private fun collectTargetMethodParameters(targetMethod: PsiMethod): List<Parameter> {
+            val parameters = targetMethod.parameterList.parameters
+            val list = ArrayList<Parameter>(parameters.size)
+
+            // Special handling for enums: When compiled, the Java compiler
+            // prepends the name and the ordinal to the constructor
+            if (targetMethod.isConstructor) {
+                val containingClass = targetMethod.containingClass
+                if (containingClass != null && containingClass.isEnum) {
+                    list.add(Parameter("enumName", PsiType.getJavaLangString(targetMethod.manager, targetMethod.resolveScope)))
+                    list.add(Parameter("ordinal", PsiType.INT))
+                }
+            }
+
+            // Add method parameters to list
+            parameters.mapTo(list, ::Parameter)
+            return list
+        }
+
+        internal fun findAnnotations(element: PsiAnnotationOwner): List<Pair<InjectorType, PsiAnnotation>> {
+            return element.annotations.mapNotNull {
+                val name = it.qualifiedName ?: return@mapNotNull null
+                val type = injectionPointAnnotations[name] ?: return@mapNotNull null
+                Pair(type, it)
+            }
+        }
+
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/signature/InvalidInjectorMethodSignatureInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/signature/InvalidInjectorMethodSignatureInspection.kt
@@ -1,0 +1,129 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.signature
+
+import com.demonwav.mcdev.platform.mixin.inspection.MixinInspection
+import com.demonwav.mcdev.platform.mixin.reference.MethodReference
+import com.demonwav.mcdev.util.isErasureEquivalentTo
+import com.demonwav.mcdev.util.synchronize
+import com.intellij.codeInsight.intention.QuickFixFactory
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.PsiParameterList
+import com.intellij.psi.codeStyle.JavaCodeStyleManager
+import com.intellij.psi.codeStyle.VariableKind
+
+class InvalidInjectorMethodSignatureInspection : MixinInspection() {
+
+    override fun getStaticDescription() = "Reports problems related to the method signature of Mixin injectors"
+
+    override fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor = Visitor(holder)
+
+    private class Visitor(private val holder: ProblemsHolder) : JavaElementVisitor() {
+
+        override fun visitMethod(method: PsiMethod) {
+            val identifier = method.nameIdentifier ?: return
+            val modifiers = method.modifierList
+
+            var reportedStatic = false
+            var reportedSignature = false
+
+            for ((type, annotation) in InjectorType.findAnnotations(modifiers)) {
+                val methodAttribute = annotation.findDeclaredAttributeValue("method") ?: continue
+                val targetMethods = MethodReference.resolveAllIfNotAmbiguous(methodAttribute) ?: continue
+
+                for (targetMethod in targetMethods) {
+                    if (!reportedStatic) {
+                        val static = targetMethod.hasModifierProperty(PsiModifier.STATIC)
+                        if (static && !modifiers.hasModifierProperty(PsiModifier.STATIC)) {
+                            reportedStatic = true
+                            holder.registerProblem(identifier, "Method must be static",
+                                    QuickFixFactory.getInstance().createModifierListFix(modifiers, PsiModifier.STATIC, true, false))
+                        }
+                    }
+
+                    if (!reportedSignature) {
+                        // Check method parameters
+                        val parameters = method.parameterList
+                        val (expectedParameters, expectedReturnType) = type.expectedMethodSignature(annotation, targetMethod) ?: continue
+
+                        if (!checkParameters(parameters, expectedParameters)) {
+                            reportedSignature = true
+
+                            holder.registerProblem(parameters,
+                                    "Method parameters do not match expected parameters for ${type.annotationName}",
+                                    createMethodParametersFix(parameters, expectedParameters))
+                        }
+
+                        if (!method.returnType!!.isErasureEquivalentTo(expectedReturnType)) {
+                            reportedSignature = true
+
+                            holder.registerProblem(method.returnTypeElement!!,
+                                    "Expected return type '${expectedReturnType.presentableText}' for ${type.annotationName} method",
+                                    QuickFixFactory.getInstance().createMethodReturnFix(method, expectedReturnType, false))
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun createMethodParametersFix(parameters: PsiParameterList, expected: List<ParameterGroup>): LocalQuickFix? {
+            // TODO: Someone should improve this: Right now we can only automatically fix if the parameters are empty
+            return if (parameters.parametersCount == 0) ParametersQuickFix(expected) else null
+        }
+
+        private fun checkParameters(parameterList: PsiParameterList, expected: List<ParameterGroup>): Boolean {
+            val parameters = parameterList.parameters
+            var pos = 0
+
+            for (group in expected) {
+                // Check if parameter group matches
+                if (group.match(parameters, pos)) {
+                    pos += group.size
+                } else if (group.required) {
+                    return false
+                }
+            }
+
+            return true
+        }
+
+    }
+
+    private class ParametersQuickFix(private val expected: List<ParameterGroup>) : LocalQuickFix {
+
+        override fun getFamilyName() = "Fix method parameters"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val parameters = descriptor.psiElement as PsiParameterList
+            parameters.synchronize(expected.flatMap {
+                if (it.default) {
+                    it.parameters?.map { JavaPsiFacade.getElementFactory(project).createParameter(
+                            it.name ?: JavaCodeStyleManager.getInstance(project)
+                                    .suggestVariableName(VariableKind.PARAMETER, null, null, it.type).names
+                                    .firstOrNull() ?: "unknown", it.type) } ?: listOf()
+                } else {
+                    listOf()
+                }
+            })
+        }
+
+    }
+
+}
+

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/signature/MethodSignature.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/signature/MethodSignature.kt
@@ -1,0 +1,15 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.signature
+
+import com.intellij.psi.PsiType
+
+internal data class MethodSignature(internal val parameters: List<ParameterGroup>, internal val returnType: PsiType)

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/signature/ParameterGroup.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/signature/ParameterGroup.kt
@@ -1,0 +1,50 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.inspection.signature
+
+import com.demonwav.mcdev.util.Parameter
+import com.demonwav.mcdev.util.isErasureEquivalentTo
+import com.intellij.psi.PsiParameter
+
+internal data class ParameterGroup(internal val parameters: List<Parameter>?,
+                                   internal val required: Boolean = parameters != null,
+                                   internal val default: Boolean = required) {
+
+    internal val size
+        get() = this.parameters?.size ?: 0
+
+    internal val wildcard
+        get() = this.parameters == null
+
+    internal fun match(parameters: Array<PsiParameter>, currentPosition: Int): Boolean {
+        if (this.parameters == null) {
+            // Wildcard parameter groups always match
+            return true
+        }
+
+        // Check if remaining parameter count is enough
+        if (currentPosition + size > parameters.size) {
+            return false
+        }
+
+        var pos = currentPosition
+
+        // Check parameter types
+        for ((_, type) in this.parameters) {
+            if (!type.isErasureEquivalentTo(parameters[pos++].type)) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/InjectionPointType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/InjectionPointType.kt
@@ -1,0 +1,76 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.reference
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT_CODE
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.INJECTION_POINT
+import com.demonwav.mcdev.util.ReferenceResolver
+import com.demonwav.mcdev.util.completeToLiteral
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.searches.AnnotatedElementsSearch
+import com.intellij.psi.search.searches.ClassInheritorsSearch
+
+internal object InjectionPointType : ReferenceResolver(), MixinReference {
+
+    override val description: String
+        get() = "injection point type '%s'"
+
+    override fun isValidAnnotation(name: String) = name == AT
+
+    override fun resolveReference(context: PsiElement): PsiElement? {
+        // Remove selectors from the injection point type for now
+        // TODO: Remove this when we have full support for @Slices
+        val value = context.constantStringValue.substringBefore(':')
+        findTypes(context, { code, psiClass ->
+            if (value == code) {
+                return psiClass
+            }
+        })
+        return null
+    }
+
+    override fun isUnresolved(context: PsiElement): Boolean {
+        return resolveReference(context) == null
+    }
+
+    override fun collectVariants(context: PsiElement): Array<Any> {
+        val list = ArrayList<LookupElementBuilder>()
+        findTypes(context, { code, _ ->
+            list.add(LookupElementBuilder.create(code).completeToLiteral(context))
+        })
+        return list.toArray()
+    }
+
+    private inline fun findTypes(context: PsiElement, consume: (String, PsiClass) -> Unit) {
+        // TODO: Caching wouldn't hurt here
+        val atCode = JavaPsiFacade.getInstance(context.project).findClass(AT_CODE, context.resolveScope)
+        if (atCode != null) {
+            // Mixin 0.6.5+, using @AtCode annotation
+            for (c in AnnotatedElementsSearch.searchPsiClasses(atCode, context.resolveScope)) {
+                c.modifierList!!.findAnnotation(AT_CODE)!!.findDeclaredAttributeValue("value")?.constantStringValue
+                    ?.let { code -> consume(code, c) }
+            }
+        } else {
+            // Older Mixin version. Resolve based on inheritors of InjectionPoint with a static final "CODE" field
+            val baseClass = JavaPsiFacade.getInstance(context.project).findClass(INJECTION_POINT, context.resolveScope) ?: return
+            for (c in ClassInheritorsSearch.search(baseClass)) {
+                (c.findFieldByName("CODE", false)?.computeConstantValue() as? String)
+                    ?.let { code -> consume(code, c) }
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/MethodReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/MethodReference.kt
@@ -1,0 +1,170 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.reference
+
+import com.demonwav.mcdev.platform.mixin.util.MemberReference
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.METHOD_INJECTORS
+import com.demonwav.mcdev.platform.mixin.util.MixinUtils
+import com.demonwav.mcdev.platform.mixin.util.findMethods
+import com.demonwav.mcdev.platform.mixin.util.memberReference
+import com.demonwav.mcdev.util.PolyReferenceResolver
+import com.demonwav.mcdev.util.completeToLiteral
+import com.demonwav.mcdev.util.constantStringValue
+import com.demonwav.mcdev.util.getClassOfElement
+import com.demonwav.mcdev.util.internalName
+import com.demonwav.mcdev.util.toResolveResults
+import com.intellij.codeInsight.completion.JavaLookupElementBuilder
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiSubstitutor
+import com.intellij.psi.ResolveResult
+import com.intellij.util.ArrayUtil
+import com.intellij.util.containers.stream
+import java.util.stream.Collectors
+import java.util.stream.Stream
+import kotlin.streams.toList
+
+internal object MethodReference : PolyReferenceResolver(), MixinReference {
+
+    override val description: String
+        get() = "method '%s' in target class"
+
+    override fun isValidAnnotation(name: String) = name in METHOD_INJECTORS
+
+    private fun getTargets(context: PsiElement): Collection<PsiClass>? {
+        val psiClass = getClassOfElement(context) ?: return null
+        val targets = MixinUtils.getAllMixedClasses(psiClass).values
+        return if (targets.isEmpty()) null else targets
+    }
+
+    override fun isUnresolved(context: PsiElement): Boolean {
+        val targetMethodInfo = MemberReference.parse(context.constantStringValue) ?: return false
+        val targets = getTargets(context) ?: return false
+        return !targets.stream().flatMap { it.findMethods(targetMethodInfo) }.findAny().isPresent
+    }
+
+    internal fun getReferenceIfAmbiguous(context: PsiElement): MemberReference? {
+        val targetReference = MemberReference.parse(context.constantStringValue) ?: return null
+        if (targetReference.descriptor != null) {
+            return null
+        }
+
+        val targets = getTargets(context) ?: return null
+        return if (isAmbiguous(targets, targetReference)) targetReference else null
+    }
+
+    private fun isAmbiguous(targets: Collection<PsiClass>, targetReference: MemberReference): Boolean {
+        return targets.stream().anyMatch { it.findMethodsByName(targetReference.name, false).size > 1 }
+    }
+
+    private fun resolve(context: PsiElement): Stream<PsiMethod>? {
+        val targetReference = MemberReference.parse(context.constantStringValue) ?: return null
+        val targets = getTargets(context) ?: return null
+        return resolve(targets, targetReference)
+    }
+
+    private fun resolve(targets: Collection<PsiClass>, targetReference: MemberReference): Stream<PsiMethod> {
+        return targets.stream()
+                .flatMap { it.findMethods(targetReference) }
+    }
+
+    internal fun resolveIfUnique(context: PsiElement): PsiMethod? {
+        return resolve(context)?.collect(Collectors.reducing<PsiMethod>({ _, _ -> null }))?.orElse(null)
+    }
+
+    internal fun resolveAllIfNotAmbiguous(context: PsiElement): List<PsiMethod>? {
+        val targetReference = MemberReference.parse(context.constantStringValue) ?: return null
+        val targets = getTargets(context) ?: return null
+
+        if (targetReference.descriptor == null && isAmbiguous(targets, targetReference)) {
+            return null
+        }
+
+        return resolve(targets, targetReference).toList()
+    }
+
+    override fun resolveReference(context: PsiElement): Array<ResolveResult> {
+        return resolve(context)?.toResolveResults() ?: ResolveResult.EMPTY_ARRAY
+    }
+
+    override fun collectVariants(context: PsiElement): Array<Any> {
+        val targets = getTargets(context) ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+        return targets.singleOrNull()?.let { collectVariants(context, it) } ?: collectVariants(context, targets)
+    }
+
+    private fun collectVariants(context: PsiElement, target: PsiClass): Array<Any> {
+        val methods = target.methods
+
+        // All methods which are not unique by their name need to be qualified with the descriptor
+        val visitedMethods = HashSet<String>()
+        val uniqueMethods = HashSet<String>()
+
+        for (method in methods) {
+            val name = method.internalName
+            if (visitedMethods.add(name)) {
+                uniqueMethods.add(name)
+            } else {
+                uniqueMethods.remove(name)
+            }
+        }
+
+        return createLookup(context, methods.stream(), uniqueMethods)
+    }
+
+    private fun collectVariants(context: PsiElement, targets: Collection<PsiClass>): Array<Any> {
+        val groupedMethods = targets.stream()
+                .flatMap { target -> target.methods.stream() }
+                .collect(Collectors.groupingBy(PsiMethod::memberReference))
+                .values
+
+        // All methods which are not unique by their name need to be qualified with the descriptor
+        val visitedMethods = HashSet<String>()
+        val uniqueMethods = HashSet<String>()
+
+        val allMethods = ArrayList<PsiMethod>(groupedMethods.size)
+
+        for (methods in groupedMethods) {
+            val firstMethod = methods.first()
+            val name = firstMethod.internalName
+            if (visitedMethods.add(name)) {
+                uniqueMethods.add(name)
+            } else {
+                uniqueMethods.remove(name)
+            }
+
+            // If we have a method with the same name and descriptor in at least
+            // as many classes as targets it should be present in all of them.
+            // Not sure how you would have more methods than targets but who cares.
+            if (methods.size >= targets.size) {
+                allMethods.add(firstMethod)
+            }
+        }
+
+        return createLookup(context, allMethods.stream(), uniqueMethods)
+    }
+
+    private fun createLookup(context: PsiElement, methods: Stream<PsiMethod>, uniqueMethods: Set<String>): Array<Any> {
+        return methods
+                .map { m ->
+                    val targetMethodInfo = if (m.internalName in uniqueMethods) {
+                        MemberReference(m.internalName)
+                    } else {
+                        m.memberReference
+                    }
+
+                    JavaLookupElementBuilder.forMethod(m, targetMethodInfo.toString(), PsiSubstitutor.EMPTY, null)
+                            .withPresentableText(m.internalName)
+                            .completeToLiteral(context)
+                }.toArray()
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/MixinReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/MixinReference.kt
@@ -1,0 +1,23 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.reference
+
+import com.intellij.psi.PsiElement
+
+internal interface MixinReference {
+
+    val description: String
+
+    fun isUnresolved(context: PsiElement): Boolean
+
+    fun isValidAnnotation(name: String): Boolean
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/MixinReferenceContributor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/MixinReferenceContributor.kt
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.reference
+
+import com.demonwav.mcdev.platform.mixin.reference.target.TargetReference
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.METHOD_INJECTORS
+import com.demonwav.mcdev.util.insideAnnotationAttribute
+import com.intellij.patterns.PsiJavaPatterns
+import com.intellij.patterns.StandardPatterns
+import com.intellij.psi.PsiReferenceContributor
+import com.intellij.psi.PsiReferenceRegistrar
+
+class MixinReferenceContributor : PsiReferenceContributor() {
+
+    override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
+        // Method references
+        registrar.registerReferenceProvider(PsiJavaPatterns.psiLiteral(StandardPatterns.string()).insideAnnotationAttribute(
+                StandardPatterns.string().oneOf(METHOD_INJECTORS), "method"), MethodReference)
+
+        // Injection point types
+        registrar.registerReferenceProvider(PsiJavaPatterns.psiLiteral(StandardPatterns.string())
+                .insideAnnotationAttribute(AT), InjectionPointType)
+
+        // Target references
+        registrar.registerReferenceProvider(PsiJavaPatterns.psiLiteral(StandardPatterns.string())
+                .insideAnnotationAttribute(AT, "target"), TargetReference)
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/ConstantStringMethodTargetReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/ConstantStringMethodTargetReference.kt
@@ -1,0 +1,87 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.reference.target
+
+import com.demonwav.mcdev.platform.mixin.util.MemberReference
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiLiteral
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiVariable
+
+internal object ConstantStringMethodTargetReference : TargetReference.MethodHandler() {
+
+    override fun createFindUsagesVisitor(context: PsiElement, targetClass: PsiClass, checkOnly: Boolean): CollectVisitor<out PsiElement>? {
+        return MemberReference.parse(context.constantStringValue)?.let({ FindUsagesVisitor(targetClass, it, checkOnly) })
+    }
+
+    override fun createCollectUsagesVisitor(): CollectVisitor<QualifiedMember<PsiMethod>> = CollectUsagesVisitor()
+
+    private fun isConstantStringMethodCall(expression: PsiMethodCallExpression): Boolean {
+        // Must return void
+        if (expression.type != PsiType.VOID) {
+            return false
+        }
+
+        val arguments = expression.argumentList
+        val argumentTypes = arguments.expressionTypes
+        if (argumentTypes.size != 1 || argumentTypes[0] != PsiType.getJavaLangString(expression.manager, expression.resolveScope)) {
+            // Must have one String parameter
+            return false
+        }
+
+        val expr = arguments.expressions[0]
+        // Expression must be constant, so either a literal or a constant field reference
+        return when (expr) {
+            is PsiLiteral -> true
+            is PsiReference -> (expr.resolve() as? PsiVariable)?.computeConstantValue() != null
+            else -> false
+        }
+    }
+
+    private class FindUsagesVisitor(private val targetClass: PsiClass, private val target: MemberReference, checkOnly: Boolean)
+        : CollectVisitor<PsiExpression>(checkOnly) {
+
+        override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
+            if (isConstantStringMethodCall(expression)) {
+                val method = expression.resolveMethod()
+                if (method != null && target.match(method,
+                        QualifiedMember.resolveQualifier(expression.methodExpression) ?: targetClass)) {
+                    addResult(expression)
+                }
+            }
+
+            super.visitMethodCallExpression(expression)
+        }
+
+    }
+
+    private class CollectUsagesVisitor : CollectVisitor<QualifiedMember<PsiMethod>>(false) {
+
+        override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
+            if (isConstantStringMethodCall(expression)) {
+                val method = expression.resolveMethod()
+                if (method != null) {
+                    addResult(QualifiedMember(method, expression.methodExpression))
+                }
+            }
+
+            super.visitMethodCallExpression(expression)
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/ConstructorTargetReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/ConstructorTargetReference.kt
@@ -1,0 +1,66 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.reference.target
+
+import com.demonwav.mcdev.util.constantStringValue
+import com.demonwav.mcdev.util.internalName
+import com.demonwav.mcdev.util.shortName
+import com.intellij.codeInsight.completion.JavaLookupElementBuilder
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiNewExpression
+
+internal object ConstructorTargetReference : TargetReference.Handler<PsiClass>() {
+
+    override fun createFindUsagesVisitor(context: PsiElement, targetClass: PsiClass, checkOnly: Boolean): CollectVisitor<out PsiElement>? {
+        val name = context.constantStringValue.replace('/', '.')
+        return FindUsagesVisitor(name, checkOnly)
+    }
+
+    override fun createCollectUsagesVisitor(): CollectVisitor<PsiClass> = CollectUsagesVisitor()
+
+    override fun createLookup(targetClass: PsiClass, element: PsiClass): LookupElementBuilder {
+        return JavaLookupElementBuilder.forClass(element, element.internalName)
+                .withPresentableText(element.shortName)
+    }
+
+    private fun resolveConstructedClass(expression: PsiNewExpression): PsiClass? {
+        return expression.anonymousClass ?: expression.classReference?.resolve() as PsiClass
+    }
+
+    private class FindUsagesVisitor(private val qualifiedName: String, checkOnly: Boolean) : CollectVisitor<PsiNewExpression>(checkOnly) {
+
+        override fun visitNewExpression(expression: PsiNewExpression) {
+            val psiClass = resolveConstructedClass(expression)
+            if (psiClass != null && psiClass.qualifiedName == this.qualifiedName) {
+                addResult(expression)
+            }
+
+            super.visitNewExpression(expression)
+        }
+
+    }
+
+    private class CollectUsagesVisitor : CollectVisitor<PsiClass>(false) {
+
+        override fun visitNewExpression(expression: PsiNewExpression) {
+            val psiClass = resolveConstructedClass(expression)
+            if (psiClass != null) {
+                addResult(psiClass)
+            }
+
+            super.visitNewExpression(expression)
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/FieldTargetReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/FieldTargetReference.kt
@@ -1,0 +1,70 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.reference.target
+
+import com.demonwav.mcdev.platform.mixin.util.MemberReference
+import com.demonwav.mcdev.platform.mixin.util.getQualifiedMemberReference
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.codeInsight.completion.JavaLookupElementBuilder
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethodReferenceExpression
+import com.intellij.psi.PsiReferenceExpression
+
+internal object FieldTargetReference : TargetReference.QualifiedHandler<PsiField>() {
+
+    override fun createFindUsagesVisitor(context: PsiElement, targetClass: PsiClass,
+                                         checkOnly: Boolean): CollectVisitor<PsiReferenceExpression>? {
+        return MemberReference.parse(context.constantStringValue)?.let({ FindUsagesVisitor(targetClass, it, checkOnly) })
+    }
+
+    override fun createCollectUsagesVisitor(): CollectVisitor<QualifiedMember<PsiField>> = CollectUsagesVisitor()
+
+    override fun createLookup(targetClass: PsiClass, m: PsiField, owner: PsiClass): LookupElementBuilder {
+        return JavaLookupElementBuilder.forField(m, m.getQualifiedMemberReference(owner).toString(), targetClass)
+                .withPresentableText(m.name!!)
+                .withLookupString(m.name!!)
+    }
+
+    private class FindUsagesVisitor(private val targetClass: PsiClass, private val target: MemberReference, checkOnly: Boolean)
+        : CollectVisitor<PsiReferenceExpression>(checkOnly) {
+
+        override fun visitReferenceExpression(expression: PsiReferenceExpression) {
+            if (expression !is PsiMethodReferenceExpression) {
+                // TODO: Optimize this so we don't need to resolve all fields to find a reference
+                val resolved = expression.resolve()
+                if (resolved is PsiField && target.match(resolved, QualifiedMember.resolveQualifier(expression) ?: targetClass)) {
+                    addResult(expression)
+                }
+            }
+
+            super.visitReferenceExpression(expression)
+        }
+    }
+
+    private class CollectUsagesVisitor : CollectVisitor<QualifiedMember<PsiField>>(false) {
+
+        override fun visitReferenceExpression(expression: PsiReferenceExpression) {
+            if (expression !is PsiMethodReferenceExpression) {
+                val resolved = expression.resolve()
+                if (resolved is PsiField) {
+                    addResult(QualifiedMember(resolved, expression))
+                }
+            }
+
+            super.visitReferenceExpression(expression)
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/MethodTargetReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/MethodTargetReference.kt
@@ -1,0 +1,119 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.reference.target
+
+import com.demonwav.mcdev.platform.mixin.util.MemberReference
+import com.demonwav.mcdev.util.constantStringValue
+import com.intellij.psi.CommonClassNames
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiForeachStatement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiNewExpression
+
+internal object MethodTargetReference : TargetReference.MethodHandler() {
+
+    override fun createFindUsagesVisitor(context: PsiElement, targetClass: PsiClass, checkOnly: Boolean): CollectVisitor<out PsiElement>? {
+        return MemberReference.parse(context.constantStringValue)?.let({ FindUsagesVisitor(targetClass, it, checkOnly) })
+    }
+
+    override fun createCollectUsagesVisitor(): CollectVisitor<QualifiedMember<PsiMethod>> = CollectUsagesVisitor()
+
+    private class FindUsagesVisitor(private val targetClass: PsiClass, private val target: MemberReference, checkOnly: Boolean)
+        : CompiledMethodsVisitor<PsiElement>(checkOnly) {
+
+        override fun visitMethodUsage(method: PsiMethod, qualifier: PsiClass?, source: PsiElement) {
+            if (target.match(method, qualifier ?: targetClass)) {
+                addResult(source)
+            }
+        }
+
+    }
+
+    private class CollectUsagesVisitor : CompiledMethodsVisitor<QualifiedMember<PsiMethod>>(false) {
+
+        override fun visitMethodUsage(method: PsiMethod, qualifier: PsiClass?, source: PsiElement) {
+            addResult(QualifiedMember(method, qualifier))
+        }
+
+    }
+
+    private abstract class CompiledMethodsVisitor<T>(checkOnly: Boolean) : CollectVisitor<T>(checkOnly) {
+
+        protected abstract fun visitMethodUsage(method: PsiMethod, qualifier: PsiClass?, source: PsiElement)
+
+        override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
+            val method = expression.resolveMethod()
+            if (method != null) {
+                val containingClass = method.containingClass
+
+                // Normally, Java uses the type of the instance to qualify the method calls
+                // However, if the method is part of java.lang.Object (e.g. equals or toString)
+                // and no class in the hierarchy of the instance overrides the method, Java will
+                // insert the call using java.lang.Object as the owner
+                val qualifier = if (method.isConstructor || containingClass?.qualifiedName == CommonClassNames.JAVA_LANG_OBJECT)
+                    containingClass else QualifiedMember.resolveQualifier(expression.methodExpression)
+
+                visitMethodUsage(method, qualifier, expression)
+            }
+
+            super.visitMethodCallExpression(expression)
+        }
+
+        override fun visitNewExpression(expression: PsiNewExpression) {
+            val constructor = expression.resolveConstructor()
+            if (constructor != null) {
+                visitMethodUsage(constructor, constructor.containingClass!!, expression)
+            }
+
+            super.visitNewExpression(expression)
+        }
+
+        override fun visitForeachStatement(statement: PsiForeachStatement) {
+            // Enhanced for loops get compiled to a loop calling next on an Iterator
+            // Since these method calls are not available in the method source we need
+            // to generate 3 virtual method calls: the call to get the Iterator
+            // (Iterable.iterator()) and "Iterator.next()" and "Iterator.hasNext()"
+
+            val type = (statement.iteratedValue?.type as? PsiClassType)?.resolve()
+            if (type != null) {
+                // Find iterator() method
+                val method = type.findMethodsByName("iterator", true).first { it.parameterList.parametersCount == 0 }
+                if (method != null) {
+                    visitMethodUsage(method, type, statement)
+                }
+            }
+
+            // Get Iterator class to resolve next and hasNext
+            val iteratorClass = JavaPsiFacade.getInstance(statement.project)
+                    .findClass(CommonClassNames.JAVA_UTIL_ITERATOR, statement.resolveScope)
+
+            if (iteratorClass != null) {
+                val hasNext = iteratorClass.findMethodsByName("hasNext", false).first { it.parameterList.parametersCount == 0 }
+                if (hasNext != null) {
+                    visitMethodUsage(hasNext, iteratorClass, statement)
+                }
+
+                val next = iteratorClass.findMethodsByName("next", false).first { it.parameterList.parametersCount == 0 }
+                if (next != null) {
+                    visitMethodUsage(next, iteratorClass, statement)
+                }
+            }
+
+            super.visitForeachStatement(statement)
+        }
+
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/TargetReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/TargetReference.kt
@@ -1,0 +1,198 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.reference.target
+
+import com.demonwav.mcdev.platform.mixin.reference.MethodReference
+import com.demonwav.mcdev.platform.mixin.reference.MixinReference
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT
+import com.demonwav.mcdev.platform.mixin.util.findSource
+import com.demonwav.mcdev.platform.mixin.util.getQualifiedMemberReference
+import com.demonwav.mcdev.util.PolyReferenceResolver
+import com.demonwav.mcdev.util.annotationFromArrayValue
+import com.demonwav.mcdev.util.annotationFromValue
+import com.demonwav.mcdev.util.completeToLiteral
+import com.demonwav.mcdev.util.constantStringValue
+import com.demonwav.mcdev.util.internalName
+import com.demonwav.mcdev.util.mapToArray
+import com.demonwav.mcdev.util.shortName
+import com.intellij.codeInsight.completion.JavaLookupElementBuilder
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.JavaRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiMember
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiQualifiedReference
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiSubstitutor
+import com.intellij.psi.PsiThisExpression
+import com.intellij.psi.ResolveResult
+import com.intellij.util.ArrayUtil
+
+internal object TargetReference : PolyReferenceResolver(), MixinReference {
+
+    override val description: String
+        get() = "target reference '%s'"
+
+    override fun isValidAnnotation(name: String) = name == AT
+
+    private fun getHandler(at: PsiAnnotation): Handler<*>? {
+        val injectionPointType = at.findDeclaredAttributeValue("value")?.constantStringValue ?: return null
+        return when (injectionPointType) {
+            "INVOKE", "INVOKE_ASSIGN" -> MethodTargetReference
+            "INVOKE_STRING" -> ConstantStringMethodTargetReference
+            "FIELD" -> FieldTargetReference
+            "NEW" -> ConstructorTargetReference
+
+            else -> null // Unsupported injection point type
+        }
+    }
+
+    internal fun usesMemberReference(context: PsiElement): Boolean {
+        val handler = getHandler(context.annotationFromArrayValue!!) ?: return false
+        return handler.usesMemberReference()
+    }
+
+    private fun getTargetMethod(at: PsiAnnotation): PsiMethod? {
+        // TODO: Right now this will only work for Mixins with a single target class
+        val methodValue = at.annotationFromArrayValue?.findDeclaredAttributeValue("method") ?: return null
+        return MethodReference.resolveIfUnique(methodValue)?.findSource()
+    }
+
+    override fun isUnresolved(context: PsiElement): Boolean {
+        val result = resolve(context, checkOnly = true) ?: return false
+        return result.isEmpty()
+    }
+
+    override fun resolveReference(context: PsiElement): Array<ResolveResult> {
+        val result = resolve(context, checkOnly = false) ?: return ResolveResult.EMPTY_ARRAY
+        return result.mapToArray(::PsiElementResolveResult)
+    }
+
+    private fun resolve(context: PsiElement, checkOnly: Boolean): List<PsiElement>? {
+        val at = context.annotationFromValue!! // @At
+        val handler = getHandler(at) ?: return null
+
+        val targetMethod = getTargetMethod(at) ?: return null
+        val codeBlock = targetMethod.body ?: return null
+
+        val visitor = handler.createFindUsagesVisitor(context, targetMethod.containingClass!!, checkOnly) ?: return null
+        codeBlock.accept(visitor)
+        return visitor.result
+    }
+
+    override fun collectVariants(context: PsiElement): Array<Any> {
+        val at = context.annotationFromValue!! // @At
+        val handler = getHandler(at) ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+
+        val targetMethod = getTargetMethod(at) ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+        val codeBlock = targetMethod.body ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+
+        return collectUsages(context, handler, codeBlock, targetMethod.containingClass!!)
+    }
+
+    private fun <T> collectUsages(context: PsiElement, handler: Handler<T>, codeBlock: PsiElement, targetClass: PsiClass): Array<Any> {
+        // Collect all possible targets
+        val visitor = handler.createCollectUsagesVisitor()
+        codeBlock.accept(visitor)
+        return visitor.result.mapToArray { handler.createLookup(targetClass, it).completeToLiteral(context) }
+    }
+
+    internal abstract class Handler<T> {
+
+        internal open fun usesMemberReference() = false
+
+        internal abstract fun createFindUsagesVisitor(context: PsiElement, targetClass: PsiClass,
+                                                      checkOnly: Boolean): CollectVisitor<out PsiElement>?
+        internal abstract fun createCollectUsagesVisitor(): CollectVisitor<T>
+
+        internal abstract fun createLookup(targetClass: PsiClass, element: T): LookupElementBuilder
+
+    }
+
+    internal abstract class QualifiedHandler<T : PsiMember> : Handler<QualifiedMember<T>>() {
+
+        override final fun usesMemberReference() = true
+
+        protected abstract fun createLookup(targetClass: PsiClass, m: T, owner: PsiClass): LookupElementBuilder
+
+        protected open fun getInternalName(m: QualifiedMember<T>): String {
+            return m.member.name!!
+        }
+
+        override final fun createLookup(targetClass: PsiClass, element: QualifiedMember<T>): LookupElementBuilder {
+            return qualifyLookup(createLookup(targetClass, element.member, element.qualifier ?: targetClass), targetClass, element)
+        }
+
+        private fun qualifyLookup(builder: LookupElementBuilder, targetClass: PsiClass, m: QualifiedMember<T>): LookupElementBuilder {
+            val owner = m.member.containingClass!!
+            return if (targetClass.manager.areElementsEquivalent(targetClass, owner)) {
+                builder
+            } else {
+                // Qualify member with name of owning class
+                builder.withPresentableText(owner.shortName + '.' + getInternalName(m))
+            }
+        }
+
+    }
+
+    internal abstract class MethodHandler : QualifiedHandler<PsiMethod>() {
+
+        override fun createLookup(targetClass: PsiClass, m: PsiMethod, owner: PsiClass): LookupElementBuilder {
+            return JavaLookupElementBuilder.forMethod(m, m.getQualifiedMemberReference(owner).toString(),
+                    PsiSubstitutor.EMPTY, targetClass)
+                    .withPresentableText(m.internalName) // Display internal name (e.g. <init> for constructors)
+                    .withLookupString(m.internalName) // Allow looking up targets by their method name
+        }
+
+        override fun getInternalName(m: QualifiedMember<PsiMethod>): String {
+            return m.member.internalName
+        }
+    }
+
+}
+
+internal data class QualifiedMember<T : PsiMember>(internal val member: T, internal val qualifier: PsiClass?) {
+    constructor(member: T, reference: PsiQualifiedReference) : this(member, resolveQualifier(reference))
+
+    internal companion object {
+
+        internal fun resolveQualifier(reference: PsiQualifiedReference): PsiClass? {
+            val qualifier = reference.qualifier ?: return null
+            if (qualifier is PsiThisExpression) {
+                return null
+            }
+
+            ((qualifier as? PsiReference)?.resolve() as? PsiClass)?.let { return it }
+            ((qualifier as? PsiExpression)?.type as? PsiClassType)?.resolve()?.let { return it }
+            return null
+        }
+
+    }
+
+}
+
+internal abstract class CollectVisitor<T>(private val checkOnly: Boolean) : JavaRecursiveElementWalkingVisitor() {
+
+    internal val result = ArrayList<T>()
+
+    protected fun addResult(element: T) {
+        this.result.add(element)
+        if (checkOnly) {
+            stopWalking()
+        }
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/util/MixinConstants.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/util/MixinConstants.kt
@@ -15,13 +15,14 @@ internal object MixinConstants {
     const val SMAP_STRATUM = "Mixin"
 
     object Classes {
-        const val INJECTION_POINT = "org.spongepowered.asm.mixin.injection.InjectionPoint"
         const val CALLBACK_INFO = "org.spongepowered.asm.mixin.injection.callback.CallbackInfo"
         const val CALLBACK_INFO_RETURNABLE = "org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable"
+        const val INJECTION_POINT = "org.spongepowered.asm.mixin.injection.InjectionPoint"
     }
 
     object Annotations {
         const val AT = "org.spongepowered.asm.mixin.injection.At"
+        const val AT_CODE = "org.spongepowered.asm.mixin.injection.InjectionPoint.AtCode"
         const val DEBUG = "org.spongepowered.asm.mixin.Debug"
         const val FINAL = "org.spongepowered.asm.mixin.Final"
         const val IMPLEMENTS = "org.spongepowered.asm.mixin.Implements"

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/util/MixinUtil.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/util/MixinUtil.kt
@@ -1,0 +1,31 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+@file:JvmName("MixinUtil")
+package com.demonwav.mcdev.platform.mixin.util
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.CALLBACK_INFO
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.CALLBACK_INFO_RETURNABLE
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiPrimitiveType
+import com.intellij.psi.PsiType
+import com.intellij.psi.search.GlobalSearchScope
+
+internal fun callbackInfoType(project: Project): PsiType? = PsiType.getTypeByName(CALLBACK_INFO, project, GlobalSearchScope.allScope(project))
+
+internal fun callbackInfoReturnableType(project: Project, context: PsiElement, returnType: PsiType): PsiType? {
+    val boxedType = if (returnType is PsiPrimitiveType) returnType.getBoxedType(context)!! else returnType
+
+    // TODO: Can we do this without looking up the PsiClass?
+    val psiClass = JavaPsiFacade.getInstance(project).findClass(CALLBACK_INFO_RETURNABLE, GlobalSearchScope.allScope(project)) ?: return null
+    return JavaPsiFacade.getElementFactory(project).createType(psiClass, boxedType)
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/McPsiElementPatterns.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/McPsiElementPatterns.kt
@@ -1,0 +1,40 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util
+
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.PsiAnnotationPattern
+import com.intellij.patterns.PsiJavaElementPattern
+import com.intellij.patterns.PsiJavaPatterns
+import com.intellij.psi.PsiAnnotationParameterList
+import com.intellij.psi.PsiElement
+
+private val ANNOTATION_ATTRIBUTE_STOP = PlatformPatterns.not(PsiJavaPatterns.psiExpression()).andNot(PsiJavaPatterns.psiNameValuePair())
+
+// PsiJavaElementPattern.insideAnnotationParam checks for the parameter list only up to 3 levels
+// It can be more if the value is for example enclosed in parentheses
+internal fun <T : PsiElement, Self : PsiJavaElementPattern<T, Self>> PsiJavaElementPattern<T, Self>
+        .insideAnnotationAttribute(annotation: PsiAnnotationPattern, attribute: String): Self {
+    return inside(true, PsiJavaPatterns.psiNameValuePair().withName(attribute)
+            .withParent(PlatformPatterns.psiElement(PsiAnnotationParameterList::class.java)
+                    .withParent(annotation)), ANNOTATION_ATTRIBUTE_STOP)
+}
+
+internal fun <T : PsiElement, Self : PsiJavaElementPattern<T, Self>> PsiJavaElementPattern<T, Self>
+        .insideAnnotationAttribute(annotation: ElementPattern<String>, attribute: String): Self {
+    return insideAnnotationAttribute(PsiJavaPatterns.psiAnnotation().qName(annotation), attribute)
+}
+
+internal fun <T : PsiElement, Self : PsiJavaElementPattern<T, Self>> PsiJavaElementPattern<T, Self>
+        .insideAnnotationAttribute(annotation: String, attribute: String = "value"): Self {
+    return insideAnnotationAttribute(PsiJavaPatterns.psiAnnotation().qName(annotation), attribute)
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/Parameter.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/Parameter.kt
@@ -1,0 +1,18 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util
+
+import com.intellij.psi.PsiParameter
+import com.intellij.psi.PsiType
+
+internal data class Parameter(val name: String?, val type: PsiType) {
+    constructor(parameter: PsiParameter) : this(parameter.name, parameter.type)
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/ReferenceResolver.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/ReferenceResolver.kt
@@ -1,0 +1,119 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util
+
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.application.runWriteAction
+import com.intellij.openapi.command.CommandProcessor
+import com.intellij.openapi.editor.Editor
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiLiteral
+import com.intellij.psi.PsiNameValuePair
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.psi.ResolveResult
+import com.intellij.util.ProcessingContext
+
+/**
+ * Provides a simple [PsiReference] implementation for a global
+ * [ReferenceResolver].
+ */
+internal abstract class ReferenceResolver : PsiReferenceProvider() {
+
+    protected abstract fun resolveReference(context: PsiElement): PsiElement?
+    protected abstract fun collectVariants(context: PsiElement): Array<Any>
+
+    fun createReference(element: PsiLiteral): PsiReference = Reference(element, this)
+    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext) = arrayOf(createReference(element as PsiLiteral))
+
+    private class Reference(element: PsiLiteral, private val resolver: ReferenceResolver) : PsiReferenceBase<PsiLiteral>(element) {
+
+        override fun resolve() = resolver.resolveReference(element.findContextElement())
+        override fun getVariants() = resolver.collectVariants(element.findContextElement())
+
+    }
+
+}
+
+/**
+ * Provides a simple [com.intellij.psi.PsiPolyVariantReference] implementation
+ * for a global [ReferenceResolver].
+ */
+internal abstract class PolyReferenceResolver : PsiReferenceProvider() {
+
+    protected abstract fun resolveReference(context: PsiElement): Array<ResolveResult>
+    protected abstract fun collectVariants(context: PsiElement): Array<Any>
+
+    fun createReference(element: PsiLiteral): PsiReference = Reference(element, this)
+    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext) = arrayOf(createReference(element as PsiLiteral))
+
+    private class Reference(element: PsiLiteral, private val resolver: PolyReferenceResolver) : PsiReferenceBase.Poly<PsiLiteral>(element) {
+
+        override fun multiResolve(incompleteCode: Boolean) = resolver.resolveReference(element.findContextElement())
+        override fun getVariants() = resolver.collectVariants(element.findContextElement())
+
+    }
+
+}
+
+private fun PsiElement.findContextElement(): PsiElement {
+    var current: PsiElement
+    var parent = this
+
+    do {
+        current = parent
+        parent = current.parent
+        if (parent is PsiNameValuePair) {
+            return current
+        }
+    } while (parent is PsiExpression)
+
+    throw IllegalStateException("Cannot find context element of $this")
+}
+
+/**
+ * Patches the [LookupElementBuilder] to replace the element with a single
+ * [PsiLiteral] when using code completion.
+ */
+internal fun LookupElementBuilder.completeToLiteral(context: PsiElement): LookupElementBuilder {
+    if (context is PsiLiteral) {
+        // Context is already a literal
+        return this
+    }
+
+    // TODO: Currently we replace everything with a single PsiLiteral,
+    // not sure how you would keep line breaks after completion
+    return withInsertHandler({ context, item ->
+                context.laterRunnable = ReplaceElementWithLiteral(context.editor, context.file, item.lookupString)
+            })
+}
+
+private class ReplaceElementWithLiteral(private val editor: Editor, private val file: PsiFile, private val text: String) : Runnable {
+
+    override fun run() {
+        // Commit changes made by code completion
+        PsiDocumentManager.getInstance(file.project).commitDocument(editor.document)
+
+        // Run command to replace PsiElement
+        CommandProcessor.getInstance().runUndoTransparentAction {
+            runWriteAction {
+                val element = file.findElementAt(editor.caretModel.offset)!!.findContextElement()
+                element.replace(JavaPsiFacade.getElementFactory(element.project).createExpressionFromText("\"$text\"", element.parent))
+            }
+        }
+    }
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -70,6 +70,9 @@
 
         <completion.contributor language="JAVA" implementationClass="com.demonwav.mcdev.platform.mixin.completion.MixinCompletionContributor"
                                 order="last, before javaLegacy"/>
+        <psi.referenceContributor language="JAVA" implementation="com.demonwav.mcdev.platform.mixin.reference.MixinReferenceContributor"/>
+        <completion.confidence language="JAVA" implementationClass="com.demonwav.mcdev.platform.mixin.completion.MixinCompletionConfidence"
+                               order="before javaSkipAutopopupInStrings"/>
 
         <!-- Project-independent Line Marker Providers -->
         <codeInsight.lineMarkerProvider language="" implementationClass="com.demonwav.mcdev.insight.ListenerLineMarkerProvider"/>
@@ -271,6 +274,60 @@
                          hasStaticDescription="true"
                          implementationClass="com.demonwav.mcdev.platform.mixin.inspection.OverwriteInspection"/>
 
+        <!-- Mixin injectors -->
+        <localInspection displayName="Invalid Mixin member reference"
+                         shortName="InvalidMemberReference"
+                         groupName="Mixin"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.inspection.reference.InvalidMemberReferenceInspection"/>
+
+        <localInspection displayName="Unresolved reference"
+                         shortName="UnresolvedMixinReference"
+                         groupName="Mixin"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.inspection.reference.UnresolvedReferenceInspection"/>
+        <localInspection displayName="Ambiguous reference"
+                         shortName="AmbiguousMixinReference"
+                         groupName="Mixin"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.inspection.reference.AmbiguousReferenceInspection"/>
+        <localInspection displayName="Unqualified member reference"
+                         shortName="UnqualifiedMemberReference"
+                         groupName="Mixin"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.inspection.reference.UnqualifiedMemberReferenceInspection" />
+
+        <localInspection displayName="Unnecessary qualified member reference"
+                         shortName="UnnecessaryQualifiedMemberReference"
+                         groupName="Mixin"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="WEAK WARNING"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.inspection.reference.UnnecessaryQualifiedMemberReferenceInspection"/>
+
+
+        <localInspection displayName="Invalid injector method signature"
+                         shortName="InvalidInjectorMethodSignature"
+                         groupName="Mixin"
+                         language="JAVA"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.inspection.signature.InvalidInjectorMethodSignatureInspection"/>
+
         <customJavadocTagProvider implementation="com.demonwav.mcdev.platform.mixin.MixinCustomJavaDocTagProvider"/>
 
         <!-- Project View Node Decorators provide the project icons -->
@@ -368,6 +425,11 @@
                 text="Overwrite Methods..."
                 description="Add an @Overwrite for the selected methods">
             <add-to-group group-id="GenerateGroup" anchor="last" />
+        </action>
+        <action class="com.demonwav.mcdev.platform.mixin.actions.CopyMixinTargetReferenceAction" id="CopyMixinTargetReferenceAction"
+                text="Copy Mixin target reference"
+                description="Copy the reference to the element for use in an injector">
+            <add-to-group relative-to-action="EditorPopupMenu2" anchor="after" group-id="EditorPopupMenu"/>
         </action>
         <action class="com.demonwav.mcdev.platform.mcp.actions.FindSrgMappingAction" id="FindSrgMappingAction"
                 text="Get SRG Name"


### PR DESCRIPTION
Adds code completion and inspections for references in the Mixin injector annotations.

**New features:**
- Code completion + inspection for method reference in `@Inject`, `@ModifyArg`, `@ModifyConstant`, `@ModifyVariable` and `@Redirect`
    - Inspection to report ambiguous references
    - Inspection to report unnecessary qualified references
- Code completion + inspection for target references of the `@At` annotation
    - Supports `INVOKE`, `INVOKE_ASSIGN`, `INVOKE_STRING`, `FIELD` and `NEW`
    - Inspection for unqualified references
- Code completion + inspection for injection point types (`INVOKE`, `FIELD`, etc)
- Inspection for `@Inject` and `@Redirect` method signatures ("should be static", method parameters, return type)
- "Copy Mixin target reference" action that copies the qualified descriptor for the `target` attribute of the `@At` annotation

Short video showing code completion (click image to open it):

[![](https://cloud.githubusercontent.com/assets/3035868/21578407/00fd686c-cf7f-11e6-8364-fc3f5f1b04c4.png)](https://download.minecrell.net/minecraft/sponge/test.mp4)

**Note:** This PR targets the `mixin-base` branch so you only see the new changes instead of also all the base classes. #123 is required for this PR.