### PR TITLE
Fix qualified names of anonymous classes. Fixes #145

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/util/McBytecodeUtil.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/McBytecodeUtil.kt
@@ -59,19 +59,15 @@ internal fun PsiType.appendDescriptor(builder: StringBuilder): StringBuilder {
 
 // Class
 
-internal val PsiClass.internalName: String
-    get() {
-        val parentClass = containingClass ?: return qualifiedName!!.replace('.', '/')
-        return buildInternalName(StringBuilder(), parentClass).toString()
-    }
+internal val PsiClass.internalName
+    get() = qualifiedName?.replace('.', '/') ?: buildInternalName(StringBuilder()).toString()
 
 internal fun PsiClass.appendInternalName(builder: StringBuilder): StringBuilder {
-    val parentClass = containingClass ?: return builder.append(qualifiedName!!.replace('.', '/'))
-    return buildInternalName(builder, parentClass)
+    return qualifiedName?.let { builder.append(it.replace('.', '/')) } ?: buildInternalName(builder)
 }
 
-private fun PsiClass.buildInternalName(builder: StringBuilder, parentClass: PsiClass): StringBuilder {
-    buildInnerName(builder, parentClass, { builder.append(it.qualifiedName!!.replace('.', '/')) })
+private fun PsiClass.buildInternalName(builder: StringBuilder): StringBuilder {
+    buildInnerName(builder, { it.qualifiedName?.replace('.', '/') })
     return builder
 }
 


### PR DESCRIPTION
The Javadocs in `PsiClass` are a bit confusing. The old version to build qualified names of anonymous or inner classes worked like this:

- If `containingClass` is null it is an outer class, therefore it must have a `qualifiedName` provided by IntelliJ. This is broken because anonymous classes don't have a `containingClass` either.
- Build the inner class name by going up the hierarchy until `containingClass` is null. As above this would have failed as soon as you hit a anonymous class.

The Javadocs of `PsiClass.qualifiedName` say:

> the qualified name of the class, or null for anonymous and local classes, and for type parameters

I was assuming this would mean that named inner classes don't have a qualified name, but that is not actually the case. So instead of checking if `containingClass` is null we need to walk up the hierarchy until we have a qualified name.

The new method checks if the class has a `qualifiedName` and returns directly. If not, it will walk up the hierarchy until `qualifiedName` returns a name (so the first named class without an anonymous parent).

Fixes #145 