### PR TITLE
Ignore case when looking up gradle modules for sponge

### DIFF
--- a/src/main/java/com/demonwav/mcdev/buildsystem/gradle/AbstractDataService.java
+++ b/src/main/java/com/demonwav/mcdev/buildsystem/gradle/AbstractDataService.java
@@ -72,7 +72,7 @@ public abstract class AbstractDataService extends AbstractProjectDataService<Lib
         for (DataNode<LibraryDependencyData> node : toImport) {
             final Module module = modelsProvider.findIdeModule(node.getData().getOwnerModule());
             allModules.add(module);
-            if (node.getData().getExternalName().startsWith(type.getGroupId() + ":" + type.getArtifactId())) {
+            if (node.getData().getExternalName().toLowerCase().startsWith(type.getGroupId() + ":" + type.getArtifactId())) {
                 goodModules.add(module);
             }
         }

--- a/src/main/java/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.form
+++ b/src/main/java/com/demonwav/mcdev/creator/ForgeProjectSettingsWizard.form
@@ -78,7 +78,7 @@
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Plugin Name"/>
+                  <text value="Mod Name"/>
                 </properties>
               </component>
               <component id="c81fa" class="javax.swing.JTextField" binding="pluginNameField">
@@ -118,7 +118,7 @@
                   <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Plugin Version"/>
+                  <text value="Mod Version"/>
                 </properties>
               </component>
               <grid id="84349" layout-manager="GridLayoutManager" row-count="1" column-count="7" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/com/demonwav/mcdev/creator/LiteLoaderProjectSettingsWizard.form
+++ b/src/main/java/com/demonwav/mcdev/creator/LiteLoaderProjectSettingsWizard.form
@@ -68,7 +68,7 @@
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Plugin Name"/>
+                  <text value="Mod Name"/>
                 </properties>
               </component>
               <component id="34efa" class="javax.swing.JTextField" binding="pluginNameField">
@@ -110,7 +110,7 @@
                   <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <text value="Plugin Version"/>
+                  <text value="Mod Version"/>
                 </properties>
               </component>
               <grid id="554a4" layout-manager="GridLayoutManager" row-count="1" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/com/demonwav/mcdev/platform/sponge/gradle/SpongeDataService.java
+++ b/src/main/java/com/demonwav/mcdev/platform/sponge/gradle/SpongeDataService.java
@@ -72,12 +72,12 @@ public class SpongeDataService extends AbstractProjectDataService<ModuleData, Mo
             })
             .filter(n -> n.getData() instanceof AbstractDependencyData)
             .peek(n -> allModules.add(modelsProvider.findIdeModule(((DependencyData) n.getData()).getOwnerModule())))
-            .filter(n -> ((AbstractDependencyData) n.getData()).getExternalName().matches("(^" + spongeMatcher + "|.*Sponge(Common|API)).*"))
+            .filter(n -> ((AbstractDependencyData) n.getData()).getExternalName().toLowerCase().matches("(^" + spongeMatcher + "|.*sponge(common|api)).*"))
             .map(n -> modelsProvider.findIdeModule(((DependencyData) n.getData()).getOwnerModule()))
             .collect(Collectors.toSet());
 
         goodModules.addAll(toImport.stream()
-            .filter(n -> n.getData().getId().contains("SpongeAPI"))
+            .filter(n -> n.getData().getId().toLowerCase().contains("spongeapi"))
             .map(n -> modelsProvider.findIdeModule(n.getData().getInternalName()))
             .collect(Collectors.toSet()));
 


### PR DESCRIPTION
This has fixed a bug for myself where my project has the gradle dependency links in lowercase.