### PR TITLE
Speed up @SidedProxy indexing.

### DIFF
--- a/src/main/java/com/demonwav/mcdev/platform/forge/inspections/sideonly/SideOnlyProjectComponent.java
+++ b/src/main/java/com/demonwav/mcdev/platform/forge/inspections/sideonly/SideOnlyProjectComponent.java
@@ -60,7 +60,7 @@ public class SideOnlyProjectComponent extends AbstractProjectComponent {
                             if (sidedProxy == null) {
                                 return;
                             }
-                            Collection<PsiField> annotatedFields = AnnotatedElementsSearch.searchElements(sidedProxy, scope, PsiField.class).findAll();
+                            Collection<PsiField> annotatedFields = AnnotatedElementsSearch.searchPsiFields(sidedProxy, scope).findAll();
                             indicator.setIndeterminate(false);
                             double index = 0;
                             for (PsiField field : annotatedFields) {

--- a/src/main/java/com/demonwav/mcdev/platform/forge/inspections/sideonly/SideOnlyProjectComponent.java
+++ b/src/main/java/com/demonwav/mcdev/platform/forge/inspections/sideonly/SideOnlyProjectComponent.java
@@ -55,12 +55,12 @@ public class SideOnlyProjectComponent extends AbstractProjectComponent {
                     public void run(@NotNull ProgressIndicator indicator) {
                         try (final AccessToken ignored = ApplicationManager.getApplication().acquireReadActionLock()) {
                             indicator.setIndeterminate(true);
-                            GlobalSearchScope scope = GlobalSearchScope.projectScope(myProject);
-                            PsiClass sidedProxy = JavaPsiFacade.getInstance(myProject).findClass(ForgeConstants.SIDED_PROXY_ANNOTATION, scope);
+                            final GlobalSearchScope scope = GlobalSearchScope.projectScope(myProject);
+                            final PsiClass sidedProxy = JavaPsiFacade.getInstance(myProject).findClass(ForgeConstants.SIDED_PROXY_ANNOTATION, scope);
                             if (sidedProxy == null) {
                                 return;
                             }
-                            Collection<PsiField> annotatedFields = AnnotatedElementsSearch.searchPsiFields(sidedProxy, scope).findAll();
+                            final Collection<PsiField> annotatedFields = AnnotatedElementsSearch.searchPsiFields(sidedProxy, scope).findAll();
                             indicator.setIndeterminate(false);
                             double index = 0;
                             for (PsiField field : annotatedFields) {

--- a/src/main/java/com/demonwav/mcdev/platform/forge/inspections/sideonly/SideOnlyProjectComponent.java
+++ b/src/main/java/com/demonwav/mcdev/platform/forge/inspections/sideonly/SideOnlyProjectComponent.java
@@ -12,6 +12,7 @@ package com.demonwav.mcdev.platform.forge.inspections.sideonly;
 
 import com.demonwav.mcdev.platform.MinecraftModule;
 import com.demonwav.mcdev.platform.forge.ForgeModuleType;
+import com.demonwav.mcdev.platform.forge.util.ForgeConstants;
 import com.intellij.openapi.application.AccessToken;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.AbstractProjectComponent;
@@ -20,11 +21,12 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.JavaRecursiveElementWalkingVisitor;
+import com.intellij.psi.JavaPsiFacade;
+import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiField;
-import com.intellij.psi.impl.search.AllClassesSearchExecutor;
 import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.search.searches.AllClassesSearch;
+import com.intellij.psi.search.searches.AnnotatedElementsSearch;
+import java.util.Collection;
 import org.jetbrains.annotations.NotNull;
 
 public class SideOnlyProjectComponent extends AbstractProjectComponent {
@@ -53,25 +55,19 @@ public class SideOnlyProjectComponent extends AbstractProjectComponent {
                     public void run(@NotNull ProgressIndicator indicator) {
                         try (final AccessToken ignored = ApplicationManager.getApplication().acquireReadActionLock()) {
                             indicator.setIndeterminate(true);
-                            final JavaRecursiveElementWalkingVisitor visitor = new JavaRecursiveElementWalkingVisitor() {
-                                @Override
-                                public void visitField(PsiField field) {
-                                    super.visitField(field);
-                                    SidedProxyAnnotator.check(field);
-                                }
-                            };
-
-                            try {
-                                final AllClassesSearchExecutor executor = new AllClassesSearchExecutor();
-                                executor.execute(
-                                    new AllClassesSearch.SearchParameters(GlobalSearchScope.projectScope(myProject), myProject),
-                                    psiClass -> {
-                                        psiClass.acceptChildren(visitor);
-                                        return true;
-                                    }
-                                );
-                            } catch (Exception ignored2) {}// I have no idea, seems like it's a bug with intellij, but I'll catch any
-                                                           // weird exceptions that pop up anyways...
+                            GlobalSearchScope scope = GlobalSearchScope.projectScope(myProject);
+                            PsiClass sidedProxy = JavaPsiFacade.getInstance(myProject).findClass(ForgeConstants.SIDED_PROXY_ANNOTATION, scope);
+                            if (sidedProxy == null) {
+                                return;
+                            }
+                            Collection<PsiField> annotatedFields = AnnotatedElementsSearch.searchElements(sidedProxy, scope, PsiField.class).findAll();
+                            indicator.setIndeterminate(false);
+                            double index = 0;
+                            for (PsiField field : annotatedFields) {
+                                SidedProxyAnnotator.check(field);
+                                index++;
+                                indicator.setFraction(index / annotatedFields.size());
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
This replaces the "all classes" search for `@SidedProxy` fields with the built-in `AnnotatedElementsSearch`, which is a lot faster.

It also makes the progress bar show actual progress. It's just in case someone has a lot of `@SidedProxy` fields. :wink: 