### PR TITLE
Switch to https and updated gradle

### DIFF
--- a/src/main/java/com/demonwav/mcdev/buildsystem/gradle/GradleBuildSystem.java
+++ b/src/main/java/com/demonwav/mcdev/buildsystem/gradle/GradleBuildSystem.java
@@ -215,7 +215,7 @@ public class GradleBuildSystem extends BuildSystem {
             try {
                 String wrapperDirPath = getRootDirectory().createChildDirectory(this, "gradle").createChildDirectory(this, "wrapper").getPath();
                 FileUtils.writeLines(new File(wrapperDirPath, "gradle-wrapper.properties"), Collections.singletonList(
-                    "distributionUrl=https\\://services.gradle.org/distributions/gradle-3.4.1-bin.zip"
+                    "distributionUrl=https\\://services.gradle.org/distributions/gradle-3.3-bin.zip"
                 ));
             } catch (IOException e) {
                 e.printStackTrace();

--- a/src/main/java/com/demonwav/mcdev/buildsystem/gradle/GradleBuildSystem.java
+++ b/src/main/java/com/demonwav/mcdev/buildsystem/gradle/GradleBuildSystem.java
@@ -215,7 +215,7 @@ public class GradleBuildSystem extends BuildSystem {
             try {
                 String wrapperDirPath = getRootDirectory().createChildDirectory(this, "gradle").createChildDirectory(this, "wrapper").getPath();
                 FileUtils.writeLines(new File(wrapperDirPath, "gradle-wrapper.properties"), Collections.singletonList(
-                    "distributionUrl=https\\://services.gradle.org/distributions/gradle-2.14.1-bin.zip"
+                    "distributionUrl=https\\://services.gradle.org/distributions/gradle-3.4.1-bin.zip"
                 ));
             } catch (IOException e) {
                 e.printStackTrace();

--- a/src/main/java/com/demonwav/mcdev/creator/MinecraftProjectCreator.java
+++ b/src/main/java/com/demonwav/mcdev/creator/MinecraftProjectCreator.java
@@ -171,7 +171,7 @@ public class MinecraftProjectCreator {
                 break;
             case SPONGE:
                 buildRepository.setId("spongepowered-repo");
-                buildRepository.setUrl("http://repo.spongepowered.org/maven/");
+                buildRepository.setUrl("https://repo.spongepowered.org/maven/");
                 buildDependency.setGroupId("org.spongepowered");
                 buildDependency.setArtifactId("spongeapi");
                 if (configuration instanceof SpongeProjectConfiguration) {
@@ -195,10 +195,10 @@ public class MinecraftProjectCreator {
             case NEPTUNE:
                 if (!((CanaryProjectConfiguration) configuration).canaryVersion.endsWith("-SNAPSHOT")) {
                     buildRepository.setId("lex-releases");
-                    buildRepository.setUrl("http://repo.lexteam.xyz/maven/releases/");
+                    buildRepository.setUrl("https://repo.lexteam.xyz/maven/releases/");
                 } else {
                     buildRepository.setId("lex-snapshots");
-                    buildRepository.setUrl("http://repo.lexteam.xyz/maven/snapshots/");
+                    buildRepository.setUrl("https://repo.lexteam.xyz/maven/snapshots/");
                 }
                 addVIRepo(buildSystem.getRepositories());
                 buildDependency.setGroupId("org.neptunepowered");

--- a/src/main/java/com/demonwav/mcdev/creator/ProjectChooserWizardStep.java
+++ b/src/main/java/com/demonwav/mcdev/creator/ProjectChooserWizardStep.java
@@ -53,7 +53,7 @@ public class ProjectChooserWizardStep extends ModuleWizardStep {
     private JCheckBox neptunePluginCheckBox;
 
     @NotNull private static final String bukkitInfo = "Create a standard " +
-            "<a href=\"http://bukkit.org/\">Bukkit</a> plugin, for use " +
+            "<a href=\"https://bukkit.org/\">Bukkit</a> plugin, for use " +
             "on CraftBukkit, Spigot, and Paper servers.";
     @NotNull private static final String spigotInfo = "Create a standard " +
             "<a href=\"https://www.spigotmc.org/\">Spigot</a> plugin, for use " +
@@ -68,7 +68,7 @@ public class ProjectChooserWizardStep extends ModuleWizardStep {
             "<a href=\"https://www.spongepowered.org/\">Sponge</a> plugin, for use " +
             "on Sponge servers.";
     @NotNull private static final String forgeInfo = "Create a standard " +
-            "<a href=\"http://files.minecraftforge.net/\">Forge</a> mod, for use " +
+            "<a href=\"https://files.minecraftforge.net/\">Forge</a> mod, for use " +
             "on Forge servers and clients.";
     @NotNull private static final String liteLoaderInfo = "Create a standard " +
             "<a href=\"http://www.liteloader.com/\">LiteLoader</a> mod, for use " +

--- a/src/main/java/com/demonwav/mcdev/platform/bukkit/BukkitProjectConfiguration.java
+++ b/src/main/java/com/demonwav/mcdev/platform/bukkit/BukkitProjectConfiguration.java
@@ -12,7 +12,7 @@
  * IntelliJ IDEA Bukkit Support Plugin
  *
  * Written by Kyle Wood (DemonWav)
- * http://demonwav.com
+ * https://github.com/DemonWav
  *
  * MIT License
  */

--- a/src/main/java/com/demonwav/mcdev/platform/forge/version/ForgeVersion.java
+++ b/src/main/java/com/demonwav/mcdev/platform/forge/version/ForgeVersion.java
@@ -33,7 +33,7 @@ public class ForgeVersion {
 
     @Nullable
     public static ForgeVersion downloadData() {
-        try (InputStream in = new URL("http://files.minecraftforge.net/maven/net/minecraftforge/forge/json").openStream()) {
+        try (InputStream in = new URL("https://files.minecraftforge.net/maven/net/minecraftforge/forge/json").openStream()) {
             final String text = IOUtils.toString(in);
 
             final Map map = new Gson().fromJson(text, Map.class);


### PR DESCRIPTION
Currently the links in the wizard redirect to the http version of forge, bukkit, etc.
Moreover plugins use gradle 2.14.1 as default gradle version.

P.S. The link to DemonWav website was changed to his github page because it redirects there (not sure if it's ok, let me know).