### PR TITLE
Disable line wrapping when inserting new shadow elements

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/completion/MixinLookupItem.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/completion/MixinLookupItem.kt
@@ -10,6 +10,7 @@
 
 package com.demonwav.mcdev.platform.mixin.completion
 
+import com.demonwav.mcdev.platform.mixin.action.disableAnnotationWrapping
 import com.demonwav.mcdev.platform.mixin.action.insertShadows
 import com.demonwav.mcdev.util.findContainingClass
 import com.intellij.codeInsight.completion.InsertionContext
@@ -48,5 +49,8 @@ private fun insertShadow(context: InsertionContext, member: PsiMember) {
     // Insert @Shadow element
     val psiClass = context.file.findElementAt(context.startOffset)?.findContainingClass() ?: return
     insertShadows(context.project, psiClass, Stream.of(member))
-    PostprocessReformattingAspect.getInstance(context.project).doPostponedFormatting()
+
+    disableAnnotationWrapping(context.project) {
+        PostprocessReformattingAspect.getInstance(context.project).doPostponedFormatting()
+    }
 }


### PR DESCRIPTION
Disables annotation wrapping for methods and fields temporarily when inserting new shadow elements. They will be still line wrapped if the file is entirely reformatted, however with these changes the plugin will insert them without line breaks now:

```java
@Shadow private int entityId;
```

The code is meh but it works. 😸 