### PR TITLE
Add code assistance for Mixin configuration files

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfigFileType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfigFileType.kt
@@ -1,0 +1,22 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config
+
+import com.demonwav.mcdev.asset.PlatformAssets
+import com.intellij.json.JsonLanguage
+import com.intellij.openapi.fileTypes.LanguageFileType
+
+object MixinConfigFileType : LanguageFileType(JsonLanguage.INSTANCE) {
+    override fun getName() = "Mixin Configuration"
+    override fun getDescription() = "Mixin Configuration"
+    override fun getDefaultExtension() = ""
+    override fun getIcon() = PlatformAssets.MIXIN_ICON
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfigFileTypeFactory.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/MixinConfigFileTypeFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config
+
+import com.intellij.openapi.fileTypes.FileNameMatcher
+import com.intellij.openapi.fileTypes.FileTypeConsumer
+import com.intellij.openapi.fileTypes.FileTypeFactory
+
+class MixinConfigFileTypeFactory : FileTypeFactory(), FileNameMatcher {
+
+    override fun createFileTypes(consumer: FileTypeConsumer) {
+        consumer.consume(MixinConfigFileType, this)
+    }
+
+    override fun getPresentableString() = "Mixin Configuration"
+    override fun accept(fileName: String) = fileName.startsWith("mixins.") && fileName.endsWith(".json")
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/ConfigPropertyInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/ConfigPropertyInspection.kt
@@ -1,0 +1,39 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.inspection
+
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.json.psi.JsonElementVisitor
+import com.intellij.json.psi.JsonProperty
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+
+abstract class ConfigPropertyInspection(private vararg val names: String) : MixinConfigInspection() {
+
+    protected abstract fun visitValue(literal: JsonStringLiteral, holder: ProblemsHolder)
+
+    protected open fun findProperty(literal: PsiElement) = (literal.parent as? JsonProperty)?.takeIf { it.value === literal }
+
+    override final fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor = Visitor(holder)
+
+    private inner class Visitor(private val holder: ProblemsHolder) : JsonElementVisitor() {
+
+        override fun visitStringLiteral(literal: JsonStringLiteral) {
+            val property = findProperty(literal) ?: return
+            if (property.name !in names) {
+                return
+            }
+
+            visitValue(literal, holder)
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/ConfigValueInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/ConfigValueInspection.kt
@@ -1,0 +1,84 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.inspection
+
+import com.demonwav.mcdev.platform.mixin.config.reference.ConfigProperty
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.json.psi.JsonArray
+import com.intellij.json.psi.JsonBooleanLiteral
+import com.intellij.json.psi.JsonElementVisitor
+import com.intellij.json.psi.JsonNumberLiteral
+import com.intellij.json.psi.JsonObject
+import com.intellij.json.psi.JsonProperty
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.json.psi.JsonValue
+import com.intellij.psi.CommonClassNames.JAVA_LANG_STRING
+import com.intellij.psi.CommonClassNames.JAVA_LANG_STRING_SHORT
+import com.intellij.psi.PsiArrayType
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiType
+import com.intellij.psi.util.PsiUtil
+
+class ConfigValueInspection : MixinConfigInspection() {
+
+    override fun getStaticDescription() = "Reports invalid values in Mixin configuration files."
+
+    override fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor = Visitor(holder)
+
+    private class Visitor(private val holder: ProblemsHolder) : JsonElementVisitor() {
+
+        override fun visitProperty(property: JsonProperty) {
+            val value = property.value ?: return
+            val targetField = ConfigProperty.resolveReference(property.nameElement as? JsonStringLiteral ?: return) as? PsiField ?: return
+            checkValue(targetField.type, value)
+        }
+
+        private fun checkValue(type: PsiType, value: JsonValue) {
+            val valid = when (type) {
+                PsiType.BOOLEAN -> value is JsonBooleanLiteral
+                PsiType.BYTE, PsiType.DOUBLE, PsiType.FLOAT, PsiType.INT, PsiType.LONG, PsiType.SHORT -> value is JsonNumberLiteral
+                is PsiArrayType -> checkArray(type.componentType, value)
+                else -> checkObject(type, value)
+            }
+
+            if (!valid) {
+                holder.registerProblem(value, "Expected value of type '${type.presentableText}'")
+            }
+        }
+
+        private fun checkArray(childType: PsiType, value: JsonValue): Boolean {
+            if (value !is JsonArray) {
+                holder.registerProblem(value, "Array expected")
+                return true
+            }
+
+            for (child in value.valueList) {
+                checkValue(childType, child)
+            }
+            return true
+        }
+
+        private fun checkObject(type: PsiType, value: JsonValue): Boolean {
+            if (type !is PsiClassType) {
+                return true // Idk, it's fine I guess
+            }
+
+            if (type.className == JAVA_LANG_STRING_SHORT && type.resolve()?.qualifiedName == JAVA_LANG_STRING) {
+                return value is JsonStringLiteral
+            }
+
+            PsiUtil.extractIterableTypeParameter(type, true)?.let { return checkArray(it, value) }
+            return value is JsonObject
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/MixinConfigInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/MixinConfigInspection.kt
@@ -1,0 +1,45 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.inspection
+
+import com.demonwav.mcdev.platform.mixin.MixinModuleType
+import com.demonwav.mcdev.platform.mixin.config.MixinConfigFileType
+import com.intellij.codeInspection.InspectionManager
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiFile
+
+abstract class MixinConfigInspection : LocalInspectionTool() {
+
+    protected abstract fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor
+
+    private fun checkFile(file: PsiFile): Boolean {
+        return file.fileType === MixinConfigFileType && MixinModuleType.isInModule(file)
+    }
+
+    override final fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        if (checkFile(holder.file)) {
+            return buildVisitor(holder)
+        }
+
+        return PsiElementVisitor.EMPTY_VISITOR
+    }
+
+    override final fun processFile(file: PsiFile, manager: InspectionManager): List<ProblemDescriptor> {
+        return if (checkFile(file)) {
+            super.processFile(file, manager)
+        } else {
+            listOf()
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/MixinPluginInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/MixinPluginInspection.kt
@@ -1,0 +1,42 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.inspection
+
+import com.demonwav.mcdev.platform.mixin.config.reference.MixinPlugin
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.MIXIN_PLUGIN
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiNameHelper
+import com.intellij.psi.util.PsiUtil
+
+class MixinPluginInspection : ConfigPropertyInspection("plugin") {
+
+    override fun getStaticDescription() = "Reports invalid Mixin plugins in Mixin configuration files."
+
+    override fun visitValue(literal: JsonStringLiteral, holder: ProblemsHolder) {
+        val pluginClass = MixinPlugin.resolve(literal) ?: return
+        if (pluginClass !is PsiClass) {
+            holder.registerProblem(literal, "Mixin plugin class expected")
+            return
+        }
+
+        val pluginInterface = MixinPlugin.findInterface(literal) ?: return
+        if (!pluginClass.isInheritor(pluginInterface, true)) {
+            holder.registerProblem(literal, "Class does not extend ${PsiNameHelper.getShortClassName(MIXIN_PLUGIN)}")
+            return
+        }
+
+        if (!PsiUtil.isInstantiatable(pluginClass)) {
+            holder.registerProblem(literal, "Plugin class is not instantiable")
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/MixinRegistrationInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/MixinRegistrationInspection.kt
@@ -1,0 +1,38 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.inspection
+
+import com.demonwav.mcdev.platform.mixin.config.reference.MixinClass
+import com.demonwav.mcdev.platform.mixin.util.isMixin
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+
+class MixinRegistrationInspection : ConfigPropertyInspection("mixins", "server", "client") {
+
+    override fun getStaticDescription() = "Reports invalid Mixin classes in Mixin configuration files."
+
+    // Literal -> Array -> Property
+    override fun findProperty(literal: PsiElement) = literal.parent?.let { super.findProperty(it) }
+
+    override fun visitValue(literal: JsonStringLiteral, holder: ProblemsHolder) {
+        val mixinClass = MixinClass.resolve(literal) ?: return
+        if (mixinClass !is PsiClass) {
+            holder.registerProblem(literal, "Mixin class expected")
+            return
+        }
+
+        if (!mixinClass.isMixin) {
+            holder.registerProblem(literal, "Specified class is not a @Mixin class")
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/UnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/inspection/UnresolvedReferenceInspection.kt
@@ -1,0 +1,41 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.inspection
+
+import com.demonwav.mcdev.util.reference.InspectionReference
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.json.psi.JsonElementVisitor
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.psi.PsiElementVisitor
+
+class UnresolvedReferenceInspection : MixinConfigInspection() {
+
+    override fun getStaticDescription() = "Reports unresolved references in Mixin configuration files."
+
+    override fun buildVisitor(holder: ProblemsHolder): PsiElementVisitor = Visitor(holder)
+
+    private class Visitor(private val holder: ProblemsHolder) : JsonElementVisitor() {
+
+        override fun visitStringLiteral(literal: JsonStringLiteral) {
+            for (reference in literal.references) {
+                if (reference !is InspectionReference) {
+                    continue
+                }
+
+                if (reference.unresolved) {
+                    holder.registerProblem(literal,"Cannot resolve ${reference.description}".format(reference.canonicalText),
+                        ProblemHighlightType.LIKE_UNKNOWN_SYMBOL, reference.rangeInElement)
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/CompatibilityLevel.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/CompatibilityLevel.kt
@@ -1,0 +1,61 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.reference
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.COMPATIBILITY_LEVEL
+import com.demonwav.mcdev.util.reference.InspectionReference
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiEnumConstant
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.util.ArrayUtil
+import com.intellij.util.ProcessingContext
+
+object CompatibilityLevel : PsiReferenceProvider() {
+
+    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> = arrayOf(Reference(element))
+
+    private class Reference(element: PsiElement) : PsiReferenceBase<PsiElement>(element), InspectionReference {
+
+        override val description
+            get() = "compatibility level '%s'"
+
+        override val unresolved
+            get() = resolve() == null
+
+        override fun resolve(): PsiElement? {
+            val compatibilityLevel = findCompatibilityLevel(element)
+            return compatibilityLevel?.findFieldByName(value, false)?.takeIf { it is PsiEnumConstant }
+        }
+
+        override fun getVariants(): Array<Any> {
+            val compatibilityLevel = findCompatibilityLevel(element) ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+            val list = ArrayList<LookupElementBuilder>()
+            for (field in compatibilityLevel.fields) {
+                if (field !is PsiEnumConstant) {
+                    continue
+                }
+
+                list.add(LookupElementBuilder.create(field.name!!))
+            }
+
+            return list.toArray()
+        }
+
+        override fun isReferenceTo(element: PsiElement) = element is PsiEnumConstant && super.isReferenceTo(element)
+
+        private fun findCompatibilityLevel(context: PsiElement) =
+            JavaPsiFacade.getInstance(context.project).findClass(COMPATIBILITY_LEVEL, context.resolveScope)
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/ConfigProperty.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/ConfigProperty.kt
@@ -1,0 +1,108 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.reference
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.MIXIN_CONFIG
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.SERIALIZED_NAME
+import com.demonwav.mcdev.util.constantStringValue
+import com.demonwav.mcdev.util.findAnnotation
+import com.demonwav.mcdev.util.ifEmpty
+import com.demonwav.mcdev.util.reference.InspectionReference
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.json.psi.JsonProperty
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.util.ArrayUtil
+import com.intellij.util.ProcessingContext
+
+object ConfigProperty : PsiReferenceProvider() {
+
+    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> =
+        arrayOf(Reference(element as JsonStringLiteral))
+
+    fun resolveReference(element: JsonStringLiteral): PsiElement? {
+        val configClass = findConfigClass(element) ?: return null
+        return findProperty(configClass, element.value)
+    }
+
+    private fun collectVariants(context: PsiElement): Array<Any> {
+        val configClass = findConfigClass(context) ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+
+        val list = ArrayList<LookupElementBuilder>()
+        forEachProperty(configClass) { _, name ->
+            list.add(LookupElementBuilder.create(name))
+        }
+        return list.toArray()
+    }
+
+    private fun findProperty(configClass: PsiClass, name: String): PsiField? {
+        forEachProperty(configClass) { field, fieldName ->
+            if (fieldName == name) {
+                return field
+            }
+        }
+
+        return null
+    }
+
+    private inline fun forEachProperty(configClass: PsiClass, func: (PsiField, String) -> Unit) {
+        for (field in configClass.fields) {
+            val name = field.findAnnotation(SERIALIZED_NAME)?.findDeclaredAttributeValue(null)?.constantStringValue ?: continue
+            func(field, name)
+        }
+    }
+
+    private fun findConfigClass(context: PsiElement): PsiClass? {
+        val mixinConfig = JavaPsiFacade.getInstance(context.project).findClass(MIXIN_CONFIG, context.resolveScope) ?: return null
+
+        val property = context.parent as JsonProperty
+
+        val path = ArrayList<String>()
+
+        var current = property.parent
+        while (current != null && current !is PsiFile) {
+            if (current is JsonProperty) {
+                path.add(current.name)
+            }
+            current = current.parent
+        }
+
+        path.ifEmpty { return mixinConfig }
+
+        // Walk to correct class
+        var currentClass = mixinConfig
+        for (i in path.lastIndex downTo 0) {
+            currentClass = (findProperty(currentClass, path[i])?.type as? PsiClassType)?.resolve() ?: return null
+        }
+        return currentClass
+    }
+
+    private class Reference(element: JsonStringLiteral) : PsiReferenceBase<JsonStringLiteral>(element), InspectionReference {
+
+        override val description: String
+            get() = "config property '%s'"
+
+        override val unresolved: Boolean
+            get() = resolve() == null
+
+        override fun resolve() = resolveReference(element)
+        override fun getVariants() = collectVariants(element)
+        override fun isReferenceTo(element: PsiElement) = element is PsiField && super.isReferenceTo(element)
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinClass.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinClass.kt
@@ -1,0 +1,40 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.reference
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MIXIN
+import com.demonwav.mcdev.util.reference.ClassNameReferenceProvider
+import com.intellij.json.psi.JsonObject
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PackageScope
+import com.intellij.psi.search.searches.AnnotatedElementsSearch
+
+object MixinClass : ClassNameReferenceProvider() {
+
+    override fun getBasePackage(element: PsiElement): String? {
+        // Literal -> Array -> Property -> Object
+        val obj = element.parent?.parent?.parent as? JsonObject ?: return null
+        return (obj.findProperty("package")?.value as? JsonStringLiteral)?.value
+    }
+
+    override fun findClasses(element: PsiElement, scope: GlobalSearchScope): List<PsiClass> {
+        val facade = JavaPsiFacade.getInstance(element.project)
+        val mixinAnnotation = facade.findClass(MIXIN, element.resolveScope) ?: return emptyList()
+
+        val packageScope = getBasePackage(element)?.let { facade.findPackage(it) }
+            ?.let { scope.intersectWith(PackageScope(it, true, true)) } ?: scope
+        return AnnotatedElementsSearch.searchPsiClasses(mixinAnnotation, packageScope).toList()
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinConfigReferenceContributor.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinConfigReferenceContributor.kt
@@ -1,0 +1,39 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.reference
+
+import com.demonwav.mcdev.platform.mixin.config.MixinConfigFileType
+import com.demonwav.mcdev.util.isPropertyKey
+import com.demonwav.mcdev.util.isPropertyValue
+import com.intellij.json.psi.JsonArray
+import com.intellij.json.psi.JsonStringLiteral
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.StandardPatterns
+import com.intellij.psi.PsiReferenceContributor
+import com.intellij.psi.PsiReferenceRegistrar
+
+class MixinConfigReferenceContributor : PsiReferenceContributor() {
+
+    override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
+        val pattern = PlatformPatterns.psiElement(JsonStringLiteral::class.java)
+            .inFile(PlatformPatterns.psiFile().withFileType(StandardPatterns.`object`(MixinConfigFileType)))
+
+        registrar.registerReferenceProvider(pattern.isPropertyKey(), ConfigProperty)
+        registrar.registerReferenceProvider(pattern.isPropertyValue("package"), MixinPackage)
+        registrar.registerReferenceProvider(pattern.isPropertyValue("plugin"), MixinPlugin)
+        registrar.registerReferenceProvider(pattern.isPropertyValue("compatibilityLevel"), CompatibilityLevel)
+
+        val mixinList = PlatformPatterns.psiElement(JsonArray::class.java)
+        registrar.registerReferenceProvider(pattern.withParent(mixinList.isPropertyValue("mixins")), MixinClass)
+        registrar.registerReferenceProvider(pattern.withParent(mixinList.isPropertyValue("server")), MixinClass)
+        registrar.registerReferenceProvider(pattern.withParent(mixinList.isPropertyValue("client")), MixinClass)
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinPackage.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinPackage.kt
@@ -1,0 +1,62 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.reference
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.MIXIN
+import com.demonwav.mcdev.util.packageName
+import com.demonwav.mcdev.util.reference.PackageNameReferenceProvider
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiPackage
+import com.intellij.psi.search.PackageScope
+import com.intellij.psi.search.searches.AnnotatedElementsSearch
+import com.intellij.util.ArrayUtil
+import com.intellij.util.PlatformIcons
+
+object MixinPackage : PackageNameReferenceProvider() {
+
+    override fun collectVariants(element: PsiElement, context: PsiElement?): Array<Any> {
+        val mixinAnnotation = JavaPsiFacade.getInstance(element.project).findClass(MIXIN, element.resolveScope)
+            ?: return ArrayUtil.EMPTY_OBJECT_ARRAY
+        return if (context == null) {
+            findPackages(mixinAnnotation, element)
+        } else {
+            findChildrenPackages(mixinAnnotation, element, context as PsiPackage)
+        }
+    }
+
+    private fun findPackages(mixinAnnotation: PsiClass, element: PsiElement): Array<Any> {
+        val packages = HashSet<String>()
+        val list = ArrayList<LookupElementBuilder>()
+
+        for (mixin in AnnotatedElementsSearch.searchPsiClasses(mixinAnnotation, element.resolveScope)) {
+            val packageName = mixin.packageName ?: continue
+            if (packages.add(packageName)) {
+                list.add(LookupElementBuilder.create(packageName).withIcon(PlatformIcons.PACKAGE_ICON))
+            }
+
+            val topLevelPackage = packageName.substringBefore('.')
+            if (packages.add(topLevelPackage)) {
+                list.add(LookupElementBuilder.create(topLevelPackage).withIcon(PlatformIcons.PACKAGE_ICON))
+            }
+        }
+
+        return list.toArray()
+    }
+
+    private fun findChildrenPackages(mixinAnnotation: PsiClass, element: PsiElement, context: PsiPackage): Array<Any> {
+        val scope = PackageScope(context, true, true).intersectWith(element.resolveScope)
+        return collectSubpackages(context, AnnotatedElementsSearch.searchPsiClasses(mixinAnnotation, scope))
+    }
+
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinPlugin.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/config/reference/MixinPlugin.kt
@@ -1,0 +1,34 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mixin.config.reference
+
+import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.MIXIN_PLUGIN
+import com.demonwav.mcdev.util.reference.ClassNameReferenceProvider
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.ClassInheritorsSearch
+import com.intellij.psi.util.PsiUtil
+
+object MixinPlugin : ClassNameReferenceProvider() {
+
+    fun findInterface(context: PsiElement): PsiClass? {
+        return JavaPsiFacade.getInstance(context.project).findClass(MIXIN_PLUGIN, context.resolveScope)
+    }
+
+    override fun findClasses(element: PsiElement, scope: GlobalSearchScope): List<PsiClass> {
+        val configInterface = findInterface(element) ?: return emptyList()
+        return ClassInheritorsSearch.search(configInterface, scope, true, true, false).filter {
+            PsiUtil.isInstantiatable(it)
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/UnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/inspection/reference/UnresolvedReferenceInspection.kt
@@ -62,7 +62,7 @@ class UnresolvedReferenceInspection : MixinInspection() {
         private fun checkResolved(resolver: MixinReference, value: PsiAnnotationMemberValue) {
             if (resolver.isUnresolved(value)) {
                 holder.registerProblem(value, "Cannot resolve ${resolver.description}".format(value.constantStringValue),
-                        ProblemHighlightType.LIKE_UNKNOWN_SYMBOL)
+                    ProblemHighlightType.LIKE_UNKNOWN_SYMBOL)
             }
         }
     }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/InjectionPointType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/InjectionPointType.kt
@@ -13,9 +13,9 @@ package com.demonwav.mcdev.platform.mixin.reference
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT_CODE
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Classes.INJECTION_POINT
-import com.demonwav.mcdev.util.ReferenceResolver
-import com.demonwav.mcdev.util.completeToLiteral
 import com.demonwav.mcdev.util.constantStringValue
+import com.demonwav.mcdev.util.reference.ReferenceResolver
+import com.demonwav.mcdev.util.reference.completeToLiteral
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
@@ -34,11 +34,11 @@ object InjectionPointType : ReferenceResolver(), MixinReference {
         // Remove selectors from the injection point type for now
         // TODO: Remove this when we have full support for @Slices
         val value = context.constantStringValue?.substringBefore(':') ?: return null
-        findTypes(context, { code, psiClass ->
+        findTypes(context) { code, psiClass ->
             if (value == code) {
                 return psiClass
             }
-        })
+        }
         return null
     }
 
@@ -48,9 +48,9 @@ object InjectionPointType : ReferenceResolver(), MixinReference {
 
     override fun collectVariants(context: PsiElement): Array<Any> {
         val list = ArrayList<LookupElementBuilder>()
-        findTypes(context, { code, _ ->
+        findTypes(context) { code, _ ->
             list.add(LookupElementBuilder.create(code).completeToLiteral(context))
-        })
+        }
         return list.toArray()
     }
 

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/MethodReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/MethodReference.kt
@@ -14,13 +14,13 @@ import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.METHOD_
 import com.demonwav.mcdev.platform.mixin.util.MixinMemberReference
 import com.demonwav.mcdev.platform.mixin.util.mixinTargets
 import com.demonwav.mcdev.util.MemberReference
-import com.demonwav.mcdev.util.PolyReferenceResolver
-import com.demonwav.mcdev.util.completeToLiteral
 import com.demonwav.mcdev.util.constantStringValue
 import com.demonwav.mcdev.util.findContainingClass
 import com.demonwav.mcdev.util.findMethods
 import com.demonwav.mcdev.util.internalName
 import com.demonwav.mcdev.util.memberReference
+import com.demonwav.mcdev.util.reference.PolyReferenceResolver
+import com.demonwav.mcdev.util.reference.completeToLiteral
 import com.demonwav.mcdev.util.toResolveResults
 import com.intellij.codeInsight.completion.JavaLookupElementBuilder
 import com.intellij.psi.PsiClass

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/TargetReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/reference/target/TargetReference.kt
@@ -15,15 +15,15 @@ import com.demonwav.mcdev.platform.mixin.reference.MixinReference
 import com.demonwav.mcdev.platform.mixin.util.MixinConstants.Annotations.AT
 import com.demonwav.mcdev.platform.mixin.util.MixinMemberReference
 import com.demonwav.mcdev.platform.mixin.util.findSource
-import com.demonwav.mcdev.util.PolyReferenceResolver
 import com.demonwav.mcdev.util.annotationFromArrayValue
 import com.demonwav.mcdev.util.annotationFromValue
-import com.demonwav.mcdev.util.completeToLiteral
 import com.demonwav.mcdev.util.constantStringValue
 import com.demonwav.mcdev.util.equivalentTo
 import com.demonwav.mcdev.util.getQualifiedMemberReference
 import com.demonwav.mcdev.util.internalName
 import com.demonwav.mcdev.util.mapToArray
+import com.demonwav.mcdev.util.reference.PolyReferenceResolver
+import com.demonwav.mcdev.util.reference.completeToLiteral
 import com.demonwav.mcdev.util.shortName
 import com.intellij.codeInsight.completion.JavaLookupElementBuilder
 import com.intellij.codeInsight.lookup.LookupElementBuilder

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mixin/util/MixinConstants.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mixin/util/MixinConstants.kt
@@ -18,8 +18,13 @@ object MixinConstants {
     object Classes {
         const val CALLBACK_INFO = "org.spongepowered.asm.mixin.injection.callback.CallbackInfo"
         const val CALLBACK_INFO_RETURNABLE = "org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable"
+        const val COMPATIBILITY_LEVEL = "org.spongepowered.asm.mixin.MixinEnvironment.CompatibilityLevel"
         const val INJECTION_POINT = "org.spongepowered.asm.mixin.injection.InjectionPoint"
         const val MIXIN_AGENT = "org.spongepowered.tools.agent.MixinAgent"
+        const val MIXIN_CONFIG = "org.spongepowered.asm.mixin.transformer.MixinConfig"
+        const val MIXIN_PLUGIN = "org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin"
+
+        const val SERIALIZED_NAME = "com.google.gson.annotations.SerializedName"
     }
 
     object Annotations {

--- a/src/main/kotlin/com/demonwav/mcdev/util/JsonPatterns.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/JsonPatterns.kt
@@ -1,0 +1,34 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util
+
+import com.intellij.json.psi.JsonElement
+import com.intellij.json.psi.JsonProperty
+import com.intellij.json.psi.JsonPsiUtil
+import com.intellij.json.psi.JsonValue
+import com.intellij.patterns.PatternCondition
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.util.ProcessingContext
+
+fun PsiElementPattern.Capture<out JsonValue>.isPropertyKey() = with(PropertyKeyCondition)!!
+
+fun PsiElementPattern.Capture<out JsonValue>.isPropertyValue(property: String) = with(
+    object : PatternCondition<JsonElement>("isPropertyValue") {
+        override fun accepts(t: JsonElement, context: ProcessingContext?): Boolean {
+            val parent = t.parent as? JsonProperty ?: return false
+            return parent.value == t && parent.name == property
+        }
+    }
+)!!
+
+private object PropertyKeyCondition : PatternCondition<JsonElement>("isPropertyKey") {
+    override fun accepts(t: JsonElement, context: ProcessingContext?) = JsonPsiUtil.isPropertyKey(t)
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/McPsiClass.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/McPsiClass.kt
@@ -19,11 +19,16 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiField
+import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameterList
 import com.intellij.psi.PsiPrimitiveType
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.annotations.Contract
+
+@get:Contract(pure = true)
+val PsiClass.packageName
+    get() = (containingFile as? PsiJavaFile)?.packageName
 
 // Type
 

--- a/src/main/kotlin/com/demonwav/mcdev/util/McPsiUtil.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/McPsiUtil.kt
@@ -11,6 +11,8 @@
 @file:JvmName("McPsiUtil")
 package com.demonwav.mcdev.util
 
+import com.intellij.psi.ElementManipulator
+import com.intellij.psi.ElementManipulators
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiDirectory
@@ -157,3 +159,7 @@ fun PsiType?.isErasureEquivalentTo(other: PsiType?): Boolean {
 @get:Contract(pure = true)
 val PsiMethod.nameAndParameterTypes: String
     get() = "$name(${parameterList.parameters.joinToString(", ") { it.type.presentableText }})"
+
+@get:Contract(pure = true)
+val <T : PsiElement> T.manipulator: ElementManipulator<T>?
+    get() = ElementManipulators.getManipulator(this)

--- a/src/main/kotlin/com/demonwav/mcdev/util/Util.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/Util.kt
@@ -91,6 +91,10 @@ inline fun <T, R> Array<T>.mapFirstNotNull(transform: (T) -> R?): R? {
     return null
 }
 
+inline fun <T, reified R> Array<T>.mapToArray(transform: (T) -> R): Array<R> {
+    return Array(size) { i -> transform(this[i]) }
+}
+
 inline fun <T, reified R> List<T>.mapToArray(transform: (T) -> R): Array<R> {
     return Array(size) { i -> transform(this[i]) }
 }

--- a/src/main/kotlin/com/demonwav/mcdev/util/reference/ClassNameReferenceProvider.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/reference/ClassNameReferenceProvider.kt
@@ -1,0 +1,105 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util.reference
+
+import com.demonwav.mcdev.util.ifEmpty
+import com.demonwav.mcdev.util.mapToArray
+import com.demonwav.mcdev.util.packageName
+import com.intellij.codeInsight.completion.JavaClassNameCompletionContributor
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiPackage
+import com.intellij.psi.ResolveResult
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.PackageScope
+import com.intellij.util.ArrayUtil
+import com.intellij.util.PlatformIcons
+
+abstract class ClassNameReferenceProvider : PackageNameReferenceProvider() {
+
+    override val description: String
+        get() = "class/package '%s'"
+
+    protected abstract fun findClasses(element: PsiElement, scope: GlobalSearchScope): List<PsiClass>
+
+    override fun canBindTo(element: PsiElement) = super.canBindTo(element) || element is PsiClass
+
+    override fun resolve(qualifiedName: String, element: PsiElement, facade: JavaPsiFacade): Array<ResolveResult> {
+        val classes = facade.findClasses(qualifiedName, element.resolveScope)
+        if (classes.isNotEmpty()) {
+            return classes.mapToArray(::PsiElementResolveResult)
+        }
+
+        return super.resolve(qualifiedName, element, facade)
+    }
+
+    override fun collectVariants(element: PsiElement, context: PsiElement?): Array<Any> {
+        return if (context != null) {
+            if (context is PsiPackage) {
+                collectSubpackages(element, context)
+            } else {
+                ArrayUtil.EMPTY_OBJECT_ARRAY // TODO: Add proper support for inner classes
+            }
+        } else {
+            collectClasses(element)
+        }
+    }
+
+    private fun collectClasses(element: PsiElement): Array<Any> {
+        val classes = findClasses(element, element.resolveScope).ifEmpty { return ArrayUtil.EMPTY_OBJECT_ARRAY }
+
+        val list = ArrayList<Any>()
+        val packages = HashSet<String>()
+
+        val basePackage = getBasePackage(element)
+
+        for (psiClass in classes) {
+            list.add(JavaClassNameCompletionContributor.createClassLookupItem(psiClass, false))
+
+            val topLevelPackage = getTopLevelPackageName(psiClass, basePackage) ?: continue
+            if (packages.add(topLevelPackage)) {
+                list.add(LookupElementBuilder.create(topLevelPackage).withIcon(PlatformIcons.PACKAGE_ICON))
+            }
+        }
+
+        return list.toArray()
+    }
+
+    private fun getTopLevelPackageName(psiClass: PsiClass, basePackage: String?): String? {
+        val packageName = psiClass.packageName ?: return null
+        val start = if (basePackage != null && packageName.startsWith(basePackage)) {
+            if (packageName.length == basePackage.length) {
+                // packageName == basePackage
+                return null
+            }
+
+            basePackage.length + 1
+        } else 0
+
+        val end = packageName.indexOf('.', start)
+        return if (end == -1) {
+            packageName.substring(start)
+        } else {
+            packageName.substring(start, end)
+        }
+    }
+
+    private fun collectSubpackages(element: PsiElement, context: PsiPackage): Array<Any> {
+        val classes = findClasses(element, PackageScope(context, true, true).intersectWith(element.resolveScope))
+            .ifEmpty { return ArrayUtil.EMPTY_OBJECT_ARRAY }
+        return collectPackageChildren(context, classes) {
+            JavaClassNameCompletionContributor.createClassLookupItem(it, false)
+        }
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/reference/InspectionReference.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/reference/InspectionReference.kt
@@ -1,0 +1,16 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util.reference
+
+interface InspectionReference {
+    val description: String
+    val unresolved: Boolean
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/reference/PackageNameReferenceProvider.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/reference/PackageNameReferenceProvider.kt
@@ -1,0 +1,166 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.util.reference
+
+import com.demonwav.mcdev.util.manipulator
+import com.demonwav.mcdev.util.packageName
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiPackage
+import com.intellij.psi.PsiQualifiedNamedElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.psi.ResolveResult
+import com.intellij.util.IncorrectOperationException
+import com.intellij.util.PlatformIcons
+import com.intellij.util.ProcessingContext
+
+abstract class PackageNameReferenceProvider : PsiReferenceProvider() {
+
+    protected open val description
+        get() = "package '%s'"
+
+    protected open fun getBasePackage(element: PsiElement): String? = null
+
+    protected open fun canBindTo(element: PsiElement) = element is PsiPackage
+
+    protected open fun resolve(qualifiedName: String, element: PsiElement, facade: JavaPsiFacade): Array<ResolveResult> {
+        facade.findPackage(qualifiedName)?.let { return arrayOf(PsiElementResolveResult(it)) }
+        return ResolveResult.EMPTY_ARRAY
+    }
+
+    protected abstract fun collectVariants(element: PsiElement, context: PsiElement?): Array<Any>
+
+    protected fun collectSubpackages(context: PsiPackage, classes: Iterable<PsiClass>): Array<Any> {
+        return collectPackageChildren(context, classes) {}
+    }
+
+    protected inline fun collectPackageChildren(context: PsiPackage, classes: Iterable<PsiClass>,
+                                                classFunc: (PsiClass) -> Any?): Array<Any> {
+        val parentPackage = context.qualifiedName
+        val subPackageStart = parentPackage.length + 1
+
+        val packages = HashSet<String>()
+        val list = ArrayList<Any>()
+
+        for (psiClass in classes) {
+            val packageName = psiClass.packageName ?: continue
+            if (!packageName.startsWith(parentPackage)) {
+                continue
+            }
+            if (packageName.length < subPackageStart) {
+                classFunc(psiClass)?.let { list.add(it) }
+                continue
+            }
+
+            val end = packageName.indexOf('.', subPackageStart)
+            val nextName = if (end == -1) packageName.substring(subPackageStart) else packageName.substring(subPackageStart, end)
+
+            if (packages.add(nextName)) {
+                list.add(LookupElementBuilder.create(nextName).withIcon(PlatformIcons.PACKAGE_ICON))
+            }
+        }
+
+        return list.toArray()
+    }
+
+    fun resolve(element: PsiElement): PsiElement? {
+        val range = element.manipulator!!.getRangeInElement(element)
+        return Reference(element, range, range.startOffset, null).multiResolve(false).firstOrNull()?.element
+    }
+
+    override final fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
+        val baseRange = element.manipulator!!.getRangeInElement(element)
+
+        val text = element.text!!
+
+        val start = baseRange.startOffset
+        val end = baseRange.endOffset
+        var pos = start
+
+        var current: Reference? = null
+
+        val list = ArrayList<PsiReference>()
+        while (true) {
+            val separatorPos = text.indexOf('.', pos)
+            if (separatorPos == -1) {
+                list.add(Reference(element, TextRange(pos, end), start, current))
+                break
+            }
+
+            if (separatorPos >= end) {
+                break
+            }
+
+            current = Reference(element, TextRange(pos, separatorPos), start, current)
+            list.add(current)
+            pos = separatorPos + 1
+
+            if (pos == end) {
+                list.add(Reference(element, TextRange(end, end), start, current))
+                break
+            }
+        }
+
+        return list.toTypedArray()
+    }
+
+    private inner class Reference(element: PsiElement, range: TextRange, start: Int, val previous: Reference?)
+        : PsiReferenceBase.Poly<PsiElement>(element, range, false), InspectionReference {
+
+        override val description: String
+            get() = this@PackageNameReferenceProvider.description
+
+        private val qualifiedRange = TextRange(start, range.endOffset)
+
+        private val qualifiedName: String
+            get() {
+                val name = qualifiedRange.substring(element.text)
+                return getBasePackage(element)?.let { it + '.' + name } ?: name
+            }
+
+        override val unresolved: Boolean
+            get() = multiResolve(false).isEmpty()
+
+        override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
+            return resolve(qualifiedName, element, JavaPsiFacade.getInstance(element.project))
+        }
+
+        override fun getVariants(): Array<Any> {
+            return collectVariants(element, previous?.multiResolve(false)?.firstOrNull()?.element)
+        }
+
+        private fun getNewName(newTarget: PsiQualifiedNamedElement): String {
+            val newName = newTarget.qualifiedName!!
+            return getBasePackage(element)?.let { newName.removePrefix(it + '.') } ?: newName
+        }
+
+        override fun bindToElement(newTarget: PsiElement): PsiElement {
+            if (!canBindTo(newTarget)) {
+                throw IncorrectOperationException("Cannot bind to $newTarget")
+            }
+
+            if (super.isReferenceTo(newTarget)) {
+                return element
+            }
+
+            val newName = getNewName(newTarget as PsiQualifiedNamedElement)
+            return element.manipulator!!.handleContentChange(element, qualifiedRange, newName)
+        }
+
+        override fun isReferenceTo(element: PsiElement) = canBindTo(element) && super.isReferenceTo(element)
+    }
+}

--- a/src/main/kotlin/com/demonwav/mcdev/util/reference/ReferenceResolver.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/util/reference/ReferenceResolver.kt
@@ -8,7 +8,7 @@
  * MIT License
  */
 
-package com.demonwav.mcdev.util
+package com.demonwav.mcdev.util.reference
 
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.application.runWriteAction
@@ -94,9 +94,9 @@ fun LookupElementBuilder.completeToLiteral(context: PsiElement): LookupElementBu
 
     // TODO: Currently we replace everything with a single PsiLiteral,
     // not sure how you would keep line breaks after completion
-    return withInsertHandler({ context, item ->
-                context.laterRunnable = ReplaceElementWithLiteral(context.editor, context.file, item.lookupString)
-            })
+    return withInsertHandler { context, item ->
+        context.laterRunnable = ReplaceElementWithLiteral(context.editor, context.file, item.lookupString)
+    }
 }
 
 private class ReplaceElementWithLiteral(private val editor: Editor, private val file: PsiFile, private val text: String) : Runnable {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -74,6 +74,10 @@
         <completion.confidence language="JAVA" implementationClass="com.demonwav.mcdev.platform.mixin.completion.MixinCompletionConfidence"
                                order="before javaSkipAutopopupInStrings"/>
 
+        <!-- Mixin configuration -->
+        <fileTypeFactory implementation="com.demonwav.mcdev.platform.mixin.config.MixinConfigFileTypeFactory"/>
+        <psi.referenceContributor language="JSON" implementation="com.demonwav.mcdev.platform.mixin.config.reference.MixinConfigReferenceContributor" />
+
         <!-- Project-independent Line Marker Providers -->
         <codeInsight.lineMarkerProvider language="" implementationClass="com.demonwav.mcdev.insight.ListenerLineMarkerProvider"/>
         <codeInsight.lineMarkerProvider language="" implementationClass="com.demonwav.mcdev.insight.ColorLineMarkerProvider"/>
@@ -441,6 +445,40 @@
                          level="ERROR"
                          hasStaticDescription="true"
                          implementationClass="com.demonwav.mcdev.platform.mixin.inspection.shadow.ShadowFinalInspection"/>
+
+        <!-- Mixin Configuration -->
+        <localInspection displayName="Unresolved config reference"
+                         shortName="UnresolvedConfigReference"
+                         groupName="Mixin"
+                         language="JSON"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.config.inspection.UnresolvedReferenceInspection"/>
+        <localInspection displayName="Invalid config value"
+                         shortName="InvalidConfigValue"
+                         groupName="Mixin"
+                         language="JSON"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.config.inspection.ConfigValueInspection"/>
+        <localInspection displayName="Invalid Mixin registration"
+                         shortName="InvalidMixinRegistration"
+                         groupName="Mixin"
+                         language="JSON"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.config.inspection.MixinRegistrationInspection"/>
+        <localInspection displayName="Invalid Mixin plugin registration"
+                         shortName="InvalidMixinPluginRegistration"
+                         groupName="Mixin"
+                         language="JSON"
+                         enabledByDefault="true"
+                         level="ERROR"
+                         hasStaticDescription="true"
+                         implementationClass="com.demonwav.mcdev.platform.mixin.config.inspection.MixinPluginInspection"/>
 
         <customJavadocTagProvider implementation="com.demonwav.mcdev.platform.mixin.MixinCustomJavaDocTagProvider"/>
 


### PR DESCRIPTION
Adds code assistance for Mixin configuration files. Currently it allows completion key names, class/package names and Java compatibility levels.

Closes #144 

The implementation is very similar to #125. The tricky part is how to detect that a JSON file is a Mixin configuration. Currently, I register a custom file type that checks if a file ends with `.json` and starts with `mixins.`. That seems to be a convention that is used in most projects.

![screenshot_20170318_190113](https://cloud.githubusercontent.com/assets/3035868/24074662/571647ee-0c0d-11e7-8c3f-b3405bb08c07.png)

![screenshot_20170319_172028](https://cloud.githubusercontent.com/assets/3035868/24082586/5eb13994-0cc8-11e7-9799-4747a57570bb.png)

Also allows reading the Javadocs using the standard key:

![screenshot_20170318_190137](https://cloud.githubusercontent.com/assets/3035868/24074666/77847618-0c0d-11e7-8054-14307f21bb6b.png)

---
### TODO

- [x] Package/class references
- [x] Inspections