### PR TITLE
Add MCP/SRG unscramble support for stack traces

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/srg/McpSrgMap.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/srg/McpSrgMap.kt
@@ -25,7 +25,8 @@ import java.nio.file.Path
 class McpSrgMap private constructor(
         val classMap: ImmutableBiMap<String, String>,
         val fieldMap: ImmutableBiMap<MemberReference, MemberReference>,
-        val methodMap: ImmutableBiMap<MemberReference, MemberReference>
+        val methodMap: ImmutableBiMap<MemberReference, MemberReference>,
+        private val srgNames: Map<String, String>
 ) {
 
     @Contract(pure = true) fun getSrgClass(fullQualifiedName: String) = classMap[fullQualifiedName]
@@ -51,26 +52,36 @@ class McpSrgMap private constructor(
     @Contract(pure = true) fun mapToMcpMethod(reference: MemberReference) = getMcpMethod(reference) ?: reference
     @Contract(pure = true) fun findMcpMethod(method: PsiMethod) = getMcpMethod(method.qualifiedMemberReference)
 
+    @Contract(pure = true) fun mapSrgName(name: String) = srgNames[name]
+
     companion object {
 
         fun parse(path: Path): McpSrgMap {
             val classMapBuilder = ImmutableBiMap.builder<String, String>()
             val fieldMapBuilder = ImmutableBiMap.builder<MemberReference, MemberReference>()
             val methodMapBuilder = ImmutableBiMap.builder<MemberReference, MemberReference>()
+            val srgNames = hashMapOf<String, String>()
 
             for (line in Files.readAllLines(path)) {
                 val parts = line.split(' ')
                 when (parts[0]) {
                     "CL:" -> classMapBuilder.put(parts[1].replace('/', '.'), parts[2].replace('/', '.'))
-                    "FD:" -> fieldMapBuilder.put(SrgMemberReference.parse(parts[1]), SrgMemberReference.parse(parts[2]))
-                    "MD:" -> methodMapBuilder.put(
-                            SrgMemberReference.parse(parts[1], parts[2]),
-                            SrgMemberReference.parse(parts[3], parts[4])
-                    )
+                    "FD:" -> {
+                        val mcp = SrgMemberReference.parse(parts[1])
+                        val srg = SrgMemberReference.parse(parts[2])
+                        fieldMapBuilder.put(mcp, srg)
+                        srgNames[srg.name] = mcp.name
+                    }
+                    "MD:" -> {
+                        val mcp = SrgMemberReference.parse(parts[1], parts[2])
+                        val srg = SrgMemberReference.parse(parts[3], parts[4])
+                        methodMapBuilder.put(mcp, srg)
+                        srgNames[srg.name] =  mcp.name
+                    }
                 }
             }
 
-            return McpSrgMap(classMapBuilder.build(), fieldMapBuilder.build(), methodMapBuilder.build())
+            return McpSrgMap(classMapBuilder.build(), fieldMapBuilder.build(), methodMapBuilder.build(), srgNames)
         }
     }
 }

--- a/src/main/kotlin/com/demonwav/mcdev/platform/mcp/srg/McpUnscrambler.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/mcp/srg/McpUnscrambler.kt
@@ -1,0 +1,33 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2017 minecraft-dev
+ *
+ * MIT License
+ */
+
+package com.demonwav.mcdev.platform.mcp.srg
+
+import com.demonwav.mcdev.facet.MinecraftFacet
+import com.demonwav.mcdev.platform.mcp.McpModuleType
+import com.demonwav.mcdev.util.mapFirstNotNull
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import com.intellij.unscramble.UnscrambleSupport
+import javax.swing.JComponent
+
+class McpUnscrambler : UnscrambleSupport<JComponent> {
+
+    private val srgPattern = Regex("(?:field|func)_\\d+_[a-zA-Z]+_?")
+
+    override fun getPresentableName() = "Remap SRG names"
+
+    override fun unscramble(project: Project, text: String, logName: String, settings: JComponent?): String? {
+        val srgMap = ModuleManager.getInstance(project).modules.mapFirstNotNull {
+            MinecraftFacet.getInstance(it, McpModuleType)?.srgManager?.srgMapNow
+        } ?: return null
+        return srgPattern.replace(text) { srgMap.mapSrgName(it.value) ?: it.value }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -149,6 +149,7 @@
         <moduleService serviceImplementation="com.demonwav.mcdev.platform.mcp.McpModuleSettings"/>
 
         <gotoSymbolContributor implementation="com.demonwav.mcdev.platform.mcp.navigation.SrgMemberChooseByNameContributor" />
+        <unscrambleSupport implementation="com.demonwav.mcdev.platform.mcp.srg.McpUnscrambler"/>
         <!--endregion-->
 
         <!--region MIXIN-->


### PR DESCRIPTION
Adds a MCP SRG name unscrambler for the `Analyze Stacktrace...` feature of IntelliJ IDEA that will automatically remap all SRG names it it to make it readable.

Let's say we have a bug report with the following crash report (in SRG names): https://pastebin.com/raw/GXSFwvmh

We can go to `Analyze -> Analyze Stacktrace...`, paste the crash report and select the SRG name unscrambler:

![screenshot_20170403_152329](https://cloud.githubusercontent.com/assets/3035868/24611198/96579a72-1881-11e7-9381-041203fdb527.png)

It's then remapped and linked properly so you can directly navigate the stack trace:

![screenshot_20170403_152407](https://cloud.githubusercontent.com/assets/3035868/24611220/a88f4f50-1881-11e7-8578-884792274987.png)
