### PR TITLE
Override the JavaModuleType display name and tooltip in MinecraftModuleType.

### DIFF
--- a/src/main/kotlin/com/demonwav/mcdev/creator/MinecraftModuleBuilder.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/creator/MinecraftModuleBuilder.kt
@@ -11,6 +11,7 @@
 package com.demonwav.mcdev.creator
 
 import com.demonwav.mcdev.asset.PlatformAssets
+import com.demonwav.mcdev.platform.MinecraftModuleType
 import com.intellij.ide.util.projectWizard.JavaModuleBuilder
 import com.intellij.ide.util.projectWizard.ModuleWizardStep
 import com.intellij.ide.util.projectWizard.WizardContext

--- a/src/main/kotlin/com/demonwav/mcdev/creator/MinecraftModuleBuilder.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/creator/MinecraftModuleBuilder.kt
@@ -35,9 +35,9 @@ class MinecraftModuleBuilder : JavaModuleBuilder() {
 
     private val creator = MinecraftProjectCreator()
 
-    override fun getPresentableName() = "Minecraft"
+    override fun getPresentableName() = MinecraftModuleType.NAME
     override fun getNodeIcon() = PlatformAssets.MINECRAFT_ICON
-    override fun getGroupName() = "Minecraft"
+    override fun getGroupName() = MinecraftModuleType.NAME
     override fun getWeight() = JavaModuleBuilder.BUILD_SYSTEM_WEIGHT - 1
     override fun getBuilderId() = "MINECRAFT_MODULE"
     override fun isSuitableSdkType(sdk: SdkTypeId?) = sdk === JavaSdk.getInstance()

--- a/src/main/kotlin/com/demonwav/mcdev/creator/MinecraftModuleBuilder.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/creator/MinecraftModuleBuilder.kt
@@ -88,7 +88,7 @@ class MinecraftModuleBuilder : JavaModuleBuilder() {
     }
 
     override fun getModuleType(): ModuleType<*> = JavaModuleType.getModuleType()
-    override fun getParentGroup() = "Minecraft"
+    override fun getParentGroup() = MinecraftModuleType.NAME
 
     override fun createWizardSteps(wizardContext: WizardContext, modulesProvider: ModulesProvider): Array<ModuleWizardStep> {
         return arrayOf(

--- a/src/main/kotlin/com/demonwav/mcdev/platform/MinecraftModuleType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/MinecraftModuleType.kt
@@ -25,9 +25,9 @@ class MinecraftModuleType : JavaModuleType() {
     override fun getDescription() = "Minecraft modules are used for developing plugins or mods for <b>Minecraft</b> (Java Edition, also known as the PC Edition)."
 
     companion object {
-        private val ID = "MINECRAFT_MODULE_TYPE"
-        val NAME = "Minecraft"
-        val OPTION = "com.demonwav.mcdev.MinecraftModuleTypes"
+        private const val ID = "MINECRAFT_MODULE_TYPE"
+        const val NAME = "Minecraft"
+        const val OPTION = "com.demonwav.mcdev.MinecraftModuleTypes"
 
         val instance: MinecraftModuleType
             get() = ModuleTypeManager.getInstance().findByID(ID) as MinecraftModuleType

--- a/src/main/kotlin/com/demonwav/mcdev/platform/MinecraftModuleType.kt
+++ b/src/main/kotlin/com/demonwav/mcdev/platform/MinecraftModuleType.kt
@@ -21,9 +21,12 @@ class MinecraftModuleType : JavaModuleType() {
     override fun getBigIcon() = PlatformAssets.MINECRAFT_ICON_2X
     override fun getIcon() = PlatformAssets.MINECRAFT_ICON
     override fun getNodeIcon(isOpened: Boolean) = PlatformAssets.MINECRAFT_ICON
+    override fun getName() = NAME
+    override fun getDescription() = "Minecraft modules are used for developing plugins or mods for <b>Minecraft</b> (Java Edition, also known as the PC Edition)."
 
     companion object {
         private val ID = "MINECRAFT_MODULE_TYPE"
+        val NAME = "Minecraft"
         val OPTION = "com.demonwav.mcdev.MinecraftModuleTypes"
 
         val instance: MinecraftModuleType


### PR DESCRIPTION
The tooltip for the Minecraft option on the project creation wizard currently shows this:
`Java modules are used for developing JVM-based desktop and web applications...`
This replaces it with a Minecraft-specific description: `Minecraft modules are used for developing plugins or mods for <b>Minecraft</b> (Java Edition, also known as the PC Edition).` It also overrides the related `getName()` method I saw to prevent possible questions about that in the future.

(I specifically mentioned the Java edition because the future Pocket Edition plugins will use C#, not Java, so they will probably use a significantly different module type.)