### PR TITLE
Feature: region files support

### DIFF
--- a/src/main/kotlin/MinecraftTreeStructureProvider.kt
+++ b/src/main/kotlin/MinecraftTreeStructureProvider.kt
@@ -1,0 +1,47 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev
+
+import com.demonwav.mcdev.region.RegionFileType
+import com.demonwav.mcdev.region.RegionPsiFileNode
+import com.intellij.ide.projectView.TreeStructureProvider
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.projectView.impl.nodes.PsiFileNode
+import com.intellij.ide.util.treeView.AbstractTreeNode
+
+private fun mapMcaNode(node: AbstractTreeNode<*>): AbstractTreeNode<*> {
+    if (node is PsiFileNode) {
+        val value = node.value
+        if (value?.fileType is RegionFileType) {
+            return RegionPsiFileNode(node.project, value, node.settings)
+        }
+    }
+
+    return node
+}
+
+class MinecraftTreeStructureProvider : TreeStructureProvider {
+    override fun modify(
+        parent: AbstractTreeNode<*>,
+        children: MutableCollection<AbstractTreeNode<*>>,
+        settings: ViewSettings?
+    ) = children.mapTo(ArrayList(children.size), ::mapMcaNode)
+}

--- a/src/main/kotlin/nbt/NbtVirtualFile.kt
+++ b/src/main/kotlin/nbt/NbtVirtualFile.kt
@@ -25,6 +25,7 @@ import com.demonwav.mcdev.nbt.editor.CompressionSelection
 import com.demonwav.mcdev.nbt.editor.NbtToolbar
 import com.demonwav.mcdev.nbt.lang.NbttFile
 import com.demonwav.mcdev.nbt.lang.NbttLanguage
+import com.demonwav.mcdev.region.RegionFileSystem
 import com.demonwav.mcdev.util.loggerForTopLevel
 import com.demonwav.mcdev.util.runReadActionAsync
 import com.demonwav.mcdev.util.runWriteTaskLater
@@ -136,6 +137,7 @@ class NbtVirtualFile(
                 val filteredStream = when (toolbar.selection) {
                     CompressionSelection.GZIP -> GZIPOutputStream(this.parent.getOutputStream(requester))
                     CompressionSelection.UNCOMPRESSED -> this.parent.getOutputStream(requester)
+                    else -> throw NotImplementedError("Region-only compression algorithms are not supported for standalone NBT files")
                 }
 
                 DataOutputStream(filteredStream).use { stream ->
@@ -149,6 +151,24 @@ class NbtVirtualFile(
                     NotificationType.INFORMATION,
                 ).notify(project)
             }
+        }
+    }
+
+    // If the NBT file is part of a region file, this will be non-null and represent the file's compression algorithm
+    val compressionInRegionFile: CompressionSelection? by lazy {
+        val compressionAlgorithm = (backingFile.fileSystem as? RegionFileSystem)
+            ?.getHandler(backingFile)
+            ?.resolveChunk(backingFile.name)
+            ?.payloadCompressionAlgorithm
+
+        when (compressionAlgorithm) {
+            null -> null
+            1 -> CompressionSelection.GZIP
+            2 -> CompressionSelection.ZLIB
+            3 -> CompressionSelection.UNCOMPRESSED
+            4 -> CompressionSelection.LZ4
+            // We shouldn't be able to open NBT files if the compression algorithm is unsupported anyway
+            else -> CompressionSelection.UNCOMPRESSED
         }
     }
 }

--- a/src/main/kotlin/nbt/NbtVirtualFile.kt
+++ b/src/main/kotlin/nbt/NbtVirtualFile.kt
@@ -89,6 +89,10 @@ class NbtVirtualFile(
     override fun isTooLargeForIntelligence() = ThreeState.NO
 
     fun writeFile(requester: Any) {
+        if (!isWritable) {
+            throw IllegalStateException("Backing file is not writable")
+        }
+
         runReadActionAsync {
             val nbttFile = PsiManager.getInstance(project).findFile(this) as? NbttFile
 

--- a/src/main/kotlin/nbt/editor/CompressionComboBoxModel.kt
+++ b/src/main/kotlin/nbt/editor/CompressionComboBoxModel.kt
@@ -1,0 +1,12 @@
+package com.demonwav.mcdev.nbt.editor
+
+import com.intellij.ui.CollectionComboBoxModel
+
+private fun makeItems(isInRegionFile: Boolean) = if (isInRegionFile) {
+    CompressionSelection.entries.toList()
+} else {
+    CompressionSelection.entries.asSequence().filter { !it.regionFileOnly }.toList()
+}
+
+class CompressionComboBoxModel(isInRegionFile: Boolean) :
+    CollectionComboBoxModel<CompressionSelection?>(makeItems(isInRegionFile))

--- a/src/main/kotlin/nbt/editor/CompressionSelection.kt
+++ b/src/main/kotlin/nbt/editor/CompressionSelection.kt
@@ -22,9 +22,11 @@ package com.demonwav.mcdev.nbt.editor
 
 import com.demonwav.mcdev.asset.MCDevBundle
 
-enum class CompressionSelection(private val selectionNameFunc: () -> String) {
+enum class CompressionSelection(private val selectionNameFunc: () -> String, val regionFileOnly: Boolean = false) {
     GZIP({ MCDevBundle("nbt.compression.gzip") }),
     UNCOMPRESSED({ MCDevBundle("nbt.compression.uncompressed") }),
+    ZLIB({ MCDevBundle("nbt.compression.zlib") }, regionFileOnly = true),
+    LZ4({ MCDevBundle("nbt.compression.lz4") }, regionFileOnly = true),
     ;
 
     override fun toString(): String = selectionNameFunc()

--- a/src/main/kotlin/nbt/editor/NbtFileEditorProvider.kt
+++ b/src/main/kotlin/nbt/editor/NbtFileEditorProvider.kt
@@ -97,7 +97,7 @@ private class NbtFileEditor(
             AnActionListener.TOPIC,
             object : AnActionListener {
                 override fun afterActionPerformed(action: AnAction, event: AnActionEvent, result: AnActionResult) {
-                    if (action !is SaveAllAction) {
+                    if (action !is SaveAllAction || !file.isWritable) {
                         return
                     }
 

--- a/src/main/kotlin/nbt/editor/NbtToolbar.kt
+++ b/src/main/kotlin/nbt/editor/NbtToolbar.kt
@@ -24,14 +24,14 @@ import com.demonwav.mcdev.asset.MCDevBundle
 import com.demonwav.mcdev.nbt.NbtVirtualFile
 import com.demonwav.mcdev.util.runWriteTaskLater
 import com.intellij.openapi.ui.DialogPanel
-import com.intellij.ui.EnumComboBoxModel
 import com.intellij.ui.dsl.builder.bindItem
 import com.intellij.ui.dsl.builder.panel
 
 class NbtToolbar(nbtFile: NbtVirtualFile) {
 
     private var compressionSelection: CompressionSelection? =
-        if (nbtFile.isCompressed) CompressionSelection.GZIP else CompressionSelection.UNCOMPRESSED
+        nbtFile.compressionInRegionFile
+            ?: if (nbtFile.isCompressed) CompressionSelection.GZIP else CompressionSelection.UNCOMPRESSED
 
     val selection: CompressionSelection
         get() = compressionSelection!!
@@ -41,7 +41,9 @@ class NbtToolbar(nbtFile: NbtVirtualFile) {
     init {
         panel = panel {
             row(MCDevBundle("nbt.compression.file_type.label")) {
-                comboBox(EnumComboBoxModel(CompressionSelection::class.java))
+                val isInRegionFile = nbtFile.compressionInRegionFile != null
+
+                comboBox(CompressionComboBoxModel(isInRegionFile))
                     .bindItem(::compressionSelection)
                     .enabled(nbtFile.isWritable && nbtFile.parseSuccessful)
 

--- a/src/main/kotlin/nbt/editor/NbtToolbar.kt
+++ b/src/main/kotlin/nbt/editor/NbtToolbar.kt
@@ -44,10 +44,13 @@ class NbtToolbar(nbtFile: NbtVirtualFile) {
                 comboBox(EnumComboBoxModel(CompressionSelection::class.java))
                     .bindItem(::compressionSelection)
                     .enabled(nbtFile.isWritable && nbtFile.parseSuccessful)
-                button(MCDevBundle("nbt.compression.save.button")) {
-                    panel.apply()
-                    runWriteTaskLater {
-                        nbtFile.writeFile(this)
+
+                if (nbtFile.isWritable) {
+                    button(MCDevBundle("nbt.compression.save.button")) {
+                        panel.apply()
+                        runWriteTaskLater {
+                            nbtFile.writeFile(this)
+                        }
                     }
                 }
             }

--- a/src/main/kotlin/region/RegionArchiveHandler.kt
+++ b/src/main/kotlin/region/RegionArchiveHandler.kt
@@ -1,0 +1,85 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.region
+
+import com.intellij.openapi.vfs.impl.ArchiveHandler
+import java.io.FileNotFoundException
+import java.io.InputStream
+
+private val COORDINATE_FILE_NAME_REGEX = Regex("""^[a-z]\.(?<x>-?\d+)\.(?<z>-?\d+)\.\w+${'$'}""")
+
+/**
+ * Parses the coordinates of a region/chunk file (e.g. `r.1.-1.mca`), if representable by Int
+ */
+private fun parseFileNameCoordinates(fileName: CharSequence): Pair<Int, Int>? = COORDINATE_FILE_NAME_REGEX
+    .matchAt(fileName, 0)
+    ?.let { matchResult ->
+        val (x, z) = matchResult.destructured
+        return try {
+            Pair(x.toInt(), z.toInt())
+        } catch (e: NumberFormatException) {
+            // This may happen if the file name contains a number that's too big for an Int
+            null
+        }
+    }
+
+class RegionArchiveHandler(path: String) : ArchiveHandler(path) {
+    private val regionFile = RegionFile(file)
+
+    // Absolute region coordinates. May be null if the file has a nonstandard name.
+    private val regionXZ = parseFileNameCoordinates(path.substringAfterLast('/'))
+
+    override fun createEntriesMap() = mutableMapOf<String, EntryInfo>().apply {
+        val root = createRootEntry()
+        this[""] = root
+
+        for (chunk in regionFile) {
+            val name = if (regionXZ != null) {
+                val x = chunk.x + regionXZ.first * 32
+                val z = chunk.z + regionXZ.second * 32
+                "c.$x.$z.nbt"
+            } else {
+                val x = chunk.x
+                val z = chunk.z
+                "c.~$x.~$z.nbt"
+            }
+
+            this[name] = EntryInfo(name, false, chunk.payloadLength.toLong(), chunk.timestamp, root)
+        }
+    }
+
+    override fun getInputStream(relativePath: String): InputStream {
+        var (x, z) = parseFileNameCoordinates(relativePath.substringAfterLast('/'))
+            ?: throw FileNotFoundException("Illegal name for region file entry: $relativePath")
+
+        x = x.mod(32)
+        z = z.mod(32)
+        val entry = regionFile[x, z]?.read()
+
+        if (entry == null) {
+            throw FileNotFoundException("Chunk entry is not initialized")
+        } else {
+            return entry
+        }
+    }
+
+    override fun contentsToByteArray(relativePath: String) = getInputStream(relativePath).readBytes()
+}

--- a/src/main/kotlin/region/RegionArchiveHandler.kt
+++ b/src/main/kotlin/region/RegionArchiveHandler.kt
@@ -66,18 +66,22 @@ class RegionArchiveHandler(path: String) : ArchiveHandler(path) {
         }
     }
 
-    override fun getInputStream(relativePath: String): InputStream {
+    fun resolveChunk(relativePath: String): RegionFile.Chunk? {
         var (x, z) = parseFileNameCoordinates(relativePath.substringAfterLast('/'))
             ?: throw FileNotFoundException("Illegal name for region file entry: $relativePath")
 
         x = x.mod(32)
         z = z.mod(32)
-        val entry = regionFile[x, z]?.read()
+        return regionFile[x, z]
+    }
 
-        if (entry == null) {
+    override fun getInputStream(relativePath: String): InputStream {
+        val stream = resolveChunk(relativePath)?.read()
+
+        if (stream == null) {
             throw FileNotFoundException("Chunk entry is not initialized")
         } else {
-            return entry
+            return stream
         }
     }
 

--- a/src/main/kotlin/region/RegionFile.kt
+++ b/src/main/kotlin/region/RegionFile.kt
@@ -106,11 +106,14 @@ class RegionFile(private val filePath: File) : AutoCloseable {
         private val sectorCount: Int,
     ) {
         private val firstByte get() = (sectorOffset.toLong() * SECTOR_SIZE.toLong())
-        val payloadLength: Int
-            get() {
-                file.seek(firstByte)
-                return file.readInt()
-            }
+        val payloadLength by lazy {
+            file.seek(firstByte)
+            file.readInt()
+        }
+        val payloadCompressionAlgorithm by lazy {
+            file.seek(firstByte + 4)
+            file.readByte().toInt()
+        }
 
         internal constructor(x: Int, z: Int, chunkIndexEntry: ChunkIndexEntry) : this(
             x,
@@ -131,11 +134,10 @@ class RegionFile(private val filePath: File) : AutoCloseable {
             }
 
             val chunkReader = BufferedInputStream(FileInputStream(filePath))
-            chunkReader.skip(firstByte + 4)
-            val payloadCompression = chunkReader.readNBytes(1)[0]
+            chunkReader.skip(firstByte + 5)
             val compressedPayload = LimitedInputStream(chunkReader, payloadLength - 1)
 
-            return when (payloadCompression.toInt()) {
+            return when (payloadCompressionAlgorithm) {
                 // GZip
                 1 -> GZIPInputStream(compressedPayload)
                 // ZLib

--- a/src/main/kotlin/region/RegionFile.kt
+++ b/src/main/kotlin/region/RegionFile.kt
@@ -1,0 +1,152 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.region
+
+import com.intellij.util.io.LimitedInputStream
+import java.io.*
+import java.nio.ByteBuffer
+import java.util.zip.GZIPInputStream
+import java.util.zip.Inflater
+import java.util.zip.InflaterInputStream
+import net.jpountz.lz4.LZ4BlockInputStream
+
+private const val SECTOR_SIZE = 4096
+private const val CHUNKS_PER_REGION = 32 * 32
+
+private fun xzToIndex(x: Int, z: Int) = x + z * 32
+private fun indexToXz(index: Int) = (index.mod(32) to index.div(32))
+
+/**
+ * Helper class to read anvil region files (https://minecraft.wiki/w/Region_file_format)
+ */
+class RegionFile(private val filePath: File) : AutoCloseable {
+    private val file = RandomAccessFile(filePath, "r")
+    private val totalSectorCount = file.length() / SECTOR_SIZE
+    private val chunkIndex = arrayOfNulls<ChunkIndexEntry>(CHUNKS_PER_REGION).apply {
+        if (totalSectorCount < 2) {
+            // Invalid format
+            return@apply
+        }
+
+        val firstTwoSectors = ByteBuffer
+            .wrap(ByteArray(2 * SECTOR_SIZE).apply {
+                file.readFully(this)
+            })
+            .asIntBuffer()
+
+        for (i in 0 until CHUNKS_PER_REGION) {
+            val offsetAndSize = firstTwoSectors.get(i).toUInt()
+            val entry = ChunkIndexEntry.decode(offsetAndSize, firstTwoSectors.get(CHUNKS_PER_REGION + i))
+            if (entry.sectorOffset == 0 || entry.sectorCount == 0) {
+                continue
+            }
+
+            this[i] = entry
+        }
+    }
+
+    operator fun get(relativeChunkX: Int, relativeChunkZ: Int): Chunk? {
+        if (!(relativeChunkX in 0..32 && relativeChunkZ in 0..32)) {
+            throw IndexOutOfBoundsException("Chunk coordinates ($relativeChunkX, $relativeChunkZ) out of bounds for region file")
+        }
+
+        return chunkIndex[xzToIndex(relativeChunkX, relativeChunkZ)]?.let { entry ->
+            Chunk(
+                relativeChunkX,
+                relativeChunkZ,
+                entry
+            )
+        }
+    }
+
+    operator fun iterator(): Iterator<Chunk> = chunkIndex
+        .asSequence()
+        .mapIndexed { idx, e -> indexToXz(idx) to e }
+        .filter { it.second != null }
+        .map { (xz, e) -> Chunk(xz.first, xz.second, e!!) }
+        .iterator()
+
+    override fun close() {
+        file.close()
+    }
+
+    internal data class ChunkIndexEntry(val sectorOffset: Int, val sectorCount: Int, val timestamp: Int) {
+        companion object {
+            fun decode(offsetAndSize: UInt, timestamp: Int): ChunkIndexEntry {
+                val sectorOffset = offsetAndSize.shr(8).toInt()
+                val sectorSize = offsetAndSize.and(0b11111111u).toInt()
+                return ChunkIndexEntry(sectorOffset, sectorSize, timestamp)
+            }
+        }
+    }
+
+    inner class Chunk(
+        val x: Int,
+        val z: Int,
+        val timestamp: Long,
+        private val sectorOffset: Int,
+        private val sectorCount: Int,
+    ) {
+        private val firstByte get() = (sectorOffset.toLong() * SECTOR_SIZE.toLong())
+        val payloadLength: Int
+            get() {
+                file.seek(firstByte)
+                return file.readInt()
+            }
+
+        internal constructor(x: Int, z: Int, chunkIndexEntry: ChunkIndexEntry) : this(
+            x,
+            z,
+            chunkIndexEntry.timestamp.toLong(),
+            chunkIndexEntry.sectorOffset,
+            chunkIndexEntry.sectorCount,
+        )
+
+        fun read(): InputStream? {
+            val payloadLength = payloadLength
+            if (payloadLength > sectorCount * SECTOR_SIZE || (sectorOffset + sectorCount) > totalSectorCount) {
+                return null
+            }
+
+            if (payloadLength == 0) {
+                return InputStream.nullInputStream()
+            }
+
+            val chunkReader = BufferedInputStream(FileInputStream(filePath))
+            chunkReader.skip(firstByte + 4)
+            val payloadCompression = chunkReader.readNBytes(1)[0]
+            val compressedPayload = LimitedInputStream(chunkReader, payloadLength - 1)
+
+            return when (payloadCompression.toInt()) {
+                // GZip
+                1 -> GZIPInputStream(compressedPayload)
+                // ZLib
+                2 -> InflaterInputStream(compressedPayload, Inflater())
+                // Uncompressed
+                3 -> compressedPayload
+                // LZ4
+                4 -> LZ4BlockInputStream(compressedPayload)
+                // Custom and/or yet-to-exist algorithm
+                else -> null
+            }
+        }
+    }
+}

--- a/src/main/kotlin/region/RegionFileSystem.kt
+++ b/src/main/kotlin/region/RegionFileSystem.kt
@@ -1,0 +1,51 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.region
+
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.newvfs.ArchiveFileSystem
+import com.intellij.openapi.vfs.newvfs.VfsImplUtil
+import com.intellij.util.io.URLUtil
+
+private const val PROTOCOL = "mcdev-region"
+
+class RegionFileSystem : ArchiveFileSystem() {
+    @Suppress("CompanionObjectInExtension") // False-positive: this is a getter, not a field
+    companion object {
+        @JvmStatic
+        val INSTANCE get() = VirtualFileManager.getInstance().getFileSystem(PROTOCOL) as RegionFileSystem
+    }
+
+    override fun getProtocol() = PROTOCOL
+    override fun isReadOnly() = true
+    override fun isCorrectFileType(local: VirtualFile) = local.fileType is RegionFileType
+
+    override fun extractRootPath(path: String) = extractLocalPath(path) + URLUtil.JAR_SEPARATOR
+    override fun extractLocalPath(archivePath: String) = archivePath.substringBeforeLast(URLUtil.JAR_SEPARATOR)
+    override fun composeRootPath(localPath: String) = "$localPath${URLUtil.JAR_SEPARATOR}"
+
+    override fun findFileByPath(path: String): VirtualFile? = VfsImplUtil.findFileByPath(this, path)
+    override fun refresh(asynchronous: Boolean) = VfsImplUtil.refresh(this, asynchronous)
+    override fun refreshAndFindFileByPath(path: String) = VfsImplUtil.refreshAndFindFileByPath(this, path)
+    override fun findFileByPathIfCached(path: String) = VfsImplUtil.findFileByPathIfCached(this, path)
+    override fun getHandler(entryFile: VirtualFile) = VfsImplUtil.getHandler(this, entryFile, ::RegionArchiveHandler)
+}

--- a/src/main/kotlin/region/RegionFileSystem.kt
+++ b/src/main/kotlin/region/RegionFileSystem.kt
@@ -47,5 +47,5 @@ class RegionFileSystem : ArchiveFileSystem() {
     override fun refresh(asynchronous: Boolean) = VfsImplUtil.refresh(this, asynchronous)
     override fun refreshAndFindFileByPath(path: String) = VfsImplUtil.refreshAndFindFileByPath(this, path)
     override fun findFileByPathIfCached(path: String) = VfsImplUtil.findFileByPathIfCached(this, path)
-    override fun getHandler(entryFile: VirtualFile) = VfsImplUtil.getHandler(this, entryFile, ::RegionArchiveHandler)
+    public override fun getHandler(entryFile: VirtualFile) = VfsImplUtil.getHandler(this, entryFile, ::RegionArchiveHandler)
 }

--- a/src/main/kotlin/region/RegionFileType.kt
+++ b/src/main/kotlin/region/RegionFileType.kt
@@ -1,0 +1,36 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.region
+
+import com.demonwav.mcdev.asset.MCDevBundle
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.vfs.VirtualFile
+
+object RegionFileType : FileType {
+    override fun getDefaultExtension() = "mca"
+    override fun getIcon() = AllIcons.FileTypes.Archive
+    override fun getCharset(file: VirtualFile, content: ByteArray) = null
+    override fun getName() = "MCA"
+    override fun getDescription() = MCDevBundle("region.file_type.description")
+    override fun isBinary() = true
+    override fun isReadOnly() = true
+}

--- a/src/main/kotlin/region/RegionPsiFileNode.kt
+++ b/src/main/kotlin/region/RegionPsiFileNode.kt
@@ -1,0 +1,52 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.demonwav.mcdev.region
+
+import com.intellij.ide.projectView.ViewSettings
+import com.intellij.ide.projectView.impl.nodes.PsiFileNode
+import com.intellij.ide.util.treeView.AbstractTreeNode
+import com.intellij.openapi.project.Project
+import com.intellij.psi.*
+import com.intellij.util.containers.ContainerUtil
+
+class RegionPsiFileNode(
+    project: Project?,
+    value: PsiFile,
+    viewSettings: ViewSettings?,
+) : PsiFileNode(project, value, viewSettings) {
+    override fun getChildrenImpl(): MutableCollection<AbstractTreeNode<*>> {
+        val rootDirectory = virtualFile?.let { RegionFileSystem.INSTANCE.getRootByLocal(it) }
+        val project = project
+        if (project != null && rootDirectory != null) {
+            val psiRootDirectory = PsiManager.getInstance(project).findDirectory(rootDirectory)
+            if (psiRootDirectory != null) {
+                return psiRootDirectory
+                    .children
+                    .asSequence()
+                    .mapNotNull { it as? PsiFile }
+                    .map { PsiFileNode(it.project, it, settings) }
+                    .toMutableList()
+            }
+        }
+
+        return ContainerUtil.emptyList()
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -339,6 +339,7 @@
         <moduleBuilder id="MINECRAFT_MODULE" builderClass="com.demonwav.mcdev.creator.MinecraftModuleBuilder"/>
         <facetType implementation="com.demonwav.mcdev.facet.MinecraftFacetType"/>
         <postStartupActivity implementation="com.demonwav.mcdev.facet.MinecraftFacetDetector"/>
+        <treeStructureProvider implementation="com.demonwav.mcdev.MinecraftTreeStructureProvider"/>
         <notificationGroup id="Minecraft project creator" displayType="STICKY_BALLOON"/>
         <notificationGroup id="Minecraft facet" displayType="STICKY_BALLOON"/>
 
@@ -411,6 +412,11 @@
                                         implementationClass="com.demonwav.mcdev.nbt.lang.format.NbttParameterNameHints"/>
         <lang.fileViewProviderFactory language="NBTT"
                                       implementationClass="com.demonwav.mcdev.nbt.lang.NbttFileViewProviderFactory"/>
+
+        <!-- Region files -->
+
+        <fileType name="MCA" implementationClass="com.demonwav.mcdev.region.RegionFileType" fieldName="INSTANCE" extensions="mca"/>
+        <virtualFileSystem id="MCA" key="mcdev-region" implementationClass="com.demonwav.mcdev.region.RegionFileSystem"/>
 
         <!-- Minecraft localization files -->
         <fileType name="MCLang" language="MCLang"

--- a/src/main/resources/messages/MinecraftDevelopment.properties
+++ b/src/main/resources/messages/MinecraftDevelopment.properties
@@ -201,6 +201,8 @@ inspection.entity_data_param.fix=Replace other entity class with this entity cla
 
 nbt.compression.gzip=GZipped
 nbt.compression.uncompressed=Uncompressed
+nbt.compression.zlib=ZLib
+nbt.compression.lz4=LZ4 (block format)
 nbt.compression.file_type.label=Compression:
 nbt.compression.save.button=Save
 

--- a/src/main/resources/messages/MinecraftDevelopment.properties
+++ b/src/main/resources/messages/MinecraftDevelopment.properties
@@ -261,6 +261,8 @@ nbt.file.save_notify.parse_error.content=Due to errors in the text representatio
 nbt.file.save_notify.parse_exception.title=Error saving NBT file
 nbt.file.save_notify.parse_exception.content=An unexpected exception happened, {0} could not be saved: {1}
 
+region.file_type.description=Anvil region file
+
 intention.error.cannot.create.class.message=Cannot create class ''{0}''\n{1}
 intention.error.cannot.create.class.title=Failed to Create Class
 


### PR DESCRIPTION
Hello, I implemented a feature that closes #1798. I did this for my personal use but this PR is spontaneous, I can understand that this is not wanted as I've never got the chance to discuss that with a maintainer. No hard feelings if you aren't interested.

### Feature breakdown

- Ability to expand region files as if they were archives (which they somewhat are, to be fair)
  ![image](https://github.com/user-attachments/assets/1620d5e2-a2ac-4659-9a08-9d176f93b400)
  - Only chunks that have been initialized (world-generated) are shown
  - Since region files should only contain NBT, and since the chunks are only indexed by their XY position, the file names are completely arbitrary. I chose to use the traditional `c.x.z.nbt` naming, but this can be changed.
  - These NBT files can obviously be opened in the already-existing NBT viewer (read-only though)
  - Due to the sheer simplicity of the region format, the parser was implemented directly in my code
- The chunk coordinates inside the files are _absolute_ (or relative to the entire world, if you prefer)
  ![image](https://github.com/user-attachments/assets/9eba5d7c-4ec7-4293-960b-c413dad8936d)
  - This makes searching for a specific chunk much easier
  - The name of the MCA file is taken into consideration to know the location of the whole region itself
  - If the MCA file has an invalid name, I'm showing relative coordinates instead (I'm using tildes, as most Minecraft players would understand them as meaning "relative")
    ![image](https://github.com/user-attachments/assets/affcee05-b0dc-4f89-8647-4f59b99772ba)
- This is a bit unrelated, but this PR removes the "Save" button in the toolbar of NBT files if the file is read-only, which is important in this case -- as my code doesn't handle writing to region files -- but it might as well improve the compatibility with other extensions in scenarios where a read-only NBT file is opened
- NBT payloads inside region files are compressed using an algorithm specified within the region file (outside of the NBT payload, if that makes sense). If I didn't do anything special to handle that, the NBT editor's combo-box would always show "Uncompressed" because my code is handling the decompression before handing over the NBT payload to IntellIJ. I added a special case for that, so that the correct compression algorithm is shown. Because editing is not supported, the combobox is disabled anyway. To be frank, I'm not really happy with my code, it feels spaghetti-esque, but I'm willing to improve the structure if you have suggestions.
  ![image](https://github.com/user-attachments/assets/49d76a7b-529f-4dd6-a60c-caee7e8836a1)
  - Note: region files support algorithms that aren't typically used in typical standalone NBT files, namely ZLib and LZ4. I've made sure that they don't appear in the combobox of standalone NBT files

### What remains to be done

I prefer opening this PR before I spend too much time on the feature, as it is already sufficient for what I needed, but there are a few more things to do before it's mergeable.

- I did not bother with threads at all for the moment, i.e. the files are read on the main thread. The index of region files (the part needed to enumerate the chunk list) fits in the first 2KiB of the file, so should be really fast to read, but it would undeniably be better to do this properly, with threads. Reading the actual chunk content uses exclusively `InputStream`s that I'm handing back to IntelliJ, so I would assume that they're doing things correctly in terms of parallelism
- I'm not really handling parse errors. At best, I'm just returning eagerly from functions when something looks off, but my code probably deserves better error reporting.
- I haven't extensively tested my code.

### Disclosure

1. This is my first time ever using the IntelliJ SDK, I can't guarantee that everything I did is correct or idiomatic. I have decent (hobbyist) experience in Kotlin, though.
2. While I did not copy code from them, I wouldn't have been able to implement the custom archive type without the help of https://github.com/b3er/idea-archive-browser and their code being open source (Apache-2.0). They probably deserve a little bit of credit somewhere. Maybe in my own files, in a comment.

---

Please tell me if you're interested by this and if you have any remarks. I'll continue improving the code only if this is useful to others.
Have a great day!