### PR TITLE
Fix mixin autocomplete spinning indefinitely in classes with many lambdas

### DIFF
--- a/src/main/kotlin/platform/mixin/util/AsmUtil.kt
+++ b/src/main/kotlin/platform/mixin/util/AsmUtil.kt
@@ -30,7 +30,6 @@ import com.demonwav.mcdev.util.findMethods
 import com.demonwav.mcdev.util.findModule
 import com.demonwav.mcdev.util.findQualifiedClass
 import com.demonwav.mcdev.util.fullQualifiedName
-import com.demonwav.mcdev.util.hasSyntheticMethod
 import com.demonwav.mcdev.util.innerIndexAndName
 import com.demonwav.mcdev.util.isErasureEquivalentTo
 import com.demonwav.mcdev.util.localClasses
@@ -729,16 +728,19 @@ private fun findContainingMethod(clazz: ClassNode, lambdaMethod: MethodNode): Pa
                 else -> return@nextInsn
             }
 
-            // check if this lambda generated a synthetic method
+            // Count every LambdaMetafactory invokedynamic unconditionally so the index matches
+            // a PSI walk that counts all lambda expressions and method references without needing
+            // to call hasSyntheticMethod to filter them.
+            lambdaCount++
+            val lambdaCountThisLine =
+                lineNumber?.let { lambdaCountPerLine.merge(it, 1, Int::plus) } ?: lambdaCount
+
+            // Only record an entry when the lambda generated a synthetic method in this class.
             if (invokedMethod.owner != clazz.name) return@nextInsn
             val invokedMethodNode = clazz.findMethod(MemberReference(invokedMethod.name, invokedMethod.desc))
             if (invokedMethodNode == null || !invokedMethodNode.hasAccess(Opcodes.ACC_SYNTHETIC)) {
                 return@nextInsn
             }
-
-            lambdaCount++
-            val lambdaCountThisLine =
-                lineNumber?.let { lambdaCountPerLine.merge(it, 1, Int::plus) } ?: lambdaCount
 
             if (invokedMethod.name == lambdaMethod.name && invokedMethod.desc == lambdaMethod.desc) {
                 val locationInfo =
@@ -782,10 +784,8 @@ private fun findAssociatedLambda(project: Project, scope: GlobalSearchScope, cla
                         // walk inside the reference first, visits the qualifier first (it's first in the bytecode)
                         super.visitMethodReferenceExpression(expression)
 
-                        if (expression.hasSyntheticMethod(clazz.version)) {
-                            if (matcher.accept(expression)) {
-                                stopWalking()
-                            }
+                        if (matcher.accept(expression)) {
+                            stopWalking()
                         }
                     }
                 },


### PR DESCRIPTION
In large classes with many lambdas (e.g. Minecraft 1.20.1 `ChunkMap`/`Minecraft`/etc) mixin autocomplete for filling in `at` of `@Inject(at = "...")` stops working. More precisely, from profiling and dumping thread states, it appears to get stuck doing a ton of Psi resolution work in `hasSyntheticMethod`.

The cleanest approach I was able to find is to adjust the lambda counting code so that the indexes stored in `SourceCodeLocationInfo` can be used without requiring the expensive `hasSyntheticMethod` check in the Psi visitor. This reduces the work done during visiting to just the `Matcher`'s counting, which is not really super efficient either, but fast enough not to be an issue for interactive editing.

`hasSyntheticMethod` is now unused, but I've left it in place for the time being since it's a utility method. (Happy to remove if desired.)

Note: in the interest of full disclosure, the analysis for this problem was done in collaboration with an LLM. The fix appears straightforward and I have confirmed that it solves the problem. That said, the ASM/Psi analysis code here is quite complex and it's possible that changing the meaning of `lambdaCount` as done here may have broken something inadvertently.