### PR TITLE
Fix Write-unsafe context error in refreshSync during New Project dialog

### DIFF
--- a/src/main/kotlin/util/files.kt
+++ b/src/main/kotlin/util/files.kt
@@ -3,7 +3,7 @@
  *
  * https://mcdev.io/
  *
- * Copyright (C) 2025 minecraft-dev
+ * Copyright (C) 2026 minecraft-dev
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -33,6 +33,8 @@ import java.nio.file.Path
 import java.util.jar.Attributes
 import java.util.jar.JarFile
 import java.util.jar.Manifest
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 val VirtualFile.localFile: File
     get() = VfsUtilCore.virtualToIoFile(this)
@@ -80,17 +82,20 @@ operator fun Manifest.get(attribute: String): String? = mainAttributes.getValue(
 operator fun Manifest.get(attribute: Attributes.Name): String? = mainAttributes.getValue(attribute)
 
 suspend fun VirtualFile.refreshSync(modalityState: ModalityState): VirtualFile? {
-    fun refresh() {
-        RefreshQueue.getInstance().refresh(false, this.isDirectory, null, modalityState, this)
+    // RefreshSessionImpl asserts a write-safe context in its constructor, which fails when called
+    // from a modal dialog's dispatched coroutine. We schedule the refresh via invokeLater with
+    // the correct ModalityState so TransactionGuard sees a write-safe context.
+    suspendCancellableCoroutine { cont ->
+        ApplicationManager.getApplication().invokeLater(
+            {
+                RefreshQueue.getInstance().refresh(false, this.isDirectory, null, modalityState, this)
+                cont.resume(Unit)
+            },
+            modalityState,
+        )
     }
 
-    if (ApplicationManager.getApplication().isWriteAccessAllowed) {
-        refresh()
-    } else {
-        writeAction {
-            refresh()
-        }
+    return writeAction {
+        this@refreshSync.parent?.findOrCreateChildData(this@refreshSync, this@refreshSync.name)
     }
-
-    return this.parent?.findOrCreateChildData(this, this.name)
 }


### PR DESCRIPTION
## Problem

When opening the **New Project** wizard, the following error appears in the IDE log:

```
java.lang.Throwable: Write-unsafe context! Model changes are allowed from write-safe contexts only.
  at com.intellij.openapi.application.TransactionGuardImpl.assertWriteSafeContext
  at com.intellij.openapi.vfs.newvfs.RefreshSessionImpl.<init>
  at com.intellij.openapi.vfs.newvfs.RefreshQueueImpl.createSession
  at com.intellij.openapi.vfs.newvfs.RefreshQueue.refresh
  at com.demonwav.mcdev.util.FilesKt.refreshSync
  at com.demonwav.mcdev.creator.custom.providers.RemoteTemplateProvider.doLoadTemplates
```

`RefreshSessionImpl` asserts a write-safe context in its **constructor** via `TransactionGuard`. When `refreshSync` is called from a coroutine dispatched inside a modal dialog (the New Project wizard), `TransactionGuard` rejects the call because the dialog's modality state does not satisfy write-safe context requirements.

The previous implementation wrapped `RefreshQueue.refresh` in a `writeAction`, which did not fix the issue — the assertion fires at `RefreshSession` creation time, before any write lock is acquired.

## Fix

Schedule `RefreshQueue.refresh` via `ApplicationManager.invokeLater` with the correct `ModalityState`. This ensures `TransactionGuard` sees a write-safe context when `RefreshSessionImpl` is constructed. A `suspendCancellableCoroutine` is used to suspend the coroutine and resume it in the `invokeLater` callback, avoiding any EDT blocking.