### PR TITLE
Add completion contributor for Bukkit event handlers

### DIFF
--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionContributor.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionContributor.kt
@@ -3,7 +3,7 @@
  *
  * https://mcdev.io/
  *
- * Copyright (C) 2025 minecraft-dev
+ * Copyright (C) 2026 minecraft-dev
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionContributor.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionContributor.kt
@@ -1,3 +1,23 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.demonwav.mcdev.platform.bukkit.completion
 
 import com.intellij.codeInsight.completion.CompletionContributor

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionContributor.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionContributor.kt
@@ -1,0 +1,16 @@
+package com.demonwav.mcdev.platform.bukkit.completion
+
+import com.intellij.codeInsight.completion.CompletionContributor
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.PsiClass
+
+class BukkitEventHandlerCompletionContributor : CompletionContributor() {
+    init {
+        extend(
+            CompletionType.BASIC,
+            PlatformPatterns.psiElement().inside(PsiClass::class.java),
+            BukkitEventHandlerCompletionProvider()
+        )
+    }
+}

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
@@ -1,0 +1,80 @@
+package com.demonwav.mcdev.platform.bukkit.completion
+
+import com.intellij.codeInsight.completion.CompletionParameters
+import com.intellij.codeInsight.completion.CompletionProvider
+import com.intellij.codeInsight.completion.CompletionResultSet
+import com.intellij.codeInsight.completion.PrioritizedLookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
+import com.intellij.psi.impl.JavaPsiFacadeEx
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.searches.ClassInheritorsSearch
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.util.ProcessingContext
+import org.jetbrains.annotations.NotNull
+
+class BukkitEventHandlerCompletionProvider : CompletionProvider<CompletionParameters>() {
+    companion object {
+        const val EVENT_LISTENER = "org.bukkit.event.Listener"
+        private const val BUKKIT_EVENT_FQN = "org.bukkit.event.Event"
+    }
+
+    override fun addCompletions(
+        @NotNull completionParameters: CompletionParameters,
+        @NotNull processingContext: ProcessingContext,
+        @NotNull completionResultSet: CompletionResultSet
+    ) {
+        val prefix = completionResultSet.prefixMatcher.prefix
+        if (!prefix.startsWith("on") || prefix.length == 2) return
+
+        val position = completionParameters.position
+        val containingClass = PsiTreeUtil.getParentOfType(position, PsiClass::class.java) ?: return
+        val project: Project = position.project
+        val facade = JavaPsiFacadeEx.getInstanceEx(project)
+
+        val eventListenerClass = facade.findClass(EVENT_LISTENER, GlobalSearchScope.allScope(project)) ?: return
+        if (!containingClass.isInheritor(eventListenerClass, true)) return
+        if (PsiTreeUtil.getParentOfType(position, PsiMethod::class.java) != null) return
+
+        val scope = GlobalSearchScope.allScope(project)
+        val eventBaseClass = facade.findClass(BUKKIT_EVENT_FQN, scope) ?: return
+
+        val eventNameFilter = prefix.substring(2).lowercase()
+
+        ClassInheritorsSearch.search(eventBaseClass, scope, true)
+            .forEach { psiClass ->
+                if (psiClass.isInterface || psiClass.hasModifierProperty(PsiModifier.ABSTRACT)) {
+                    return@forEach
+                }
+
+                val eventSimpleName = psiClass.name ?: return@forEach
+                if (eventNameFilter.isNotEmpty() && !eventSimpleName.lowercase().startsWith(eventNameFilter)) {
+                    return@forEach
+                }
+
+                val lookupString = "on$eventSimpleName"
+                val methodName = lookupString.replace("Event", "")
+                val qualifiedName = psiClass.qualifiedName
+
+                val element = LookupElementBuilder
+                    .create(lookupString)
+                    .withPresentableText("$lookupString()")
+                    .withTailText(" - $qualifiedName", true)
+                    .withTypeText("@EventHandler")
+                    .withIcon(AllIcons.Nodes.Method)
+                    .withBaseLookupString(lookupString)
+                    .withBoldness(true)
+                    .withInsertHandler(BukkitEventHandlerInsertHandler(methodName, qualifiedName))
+
+                completionResultSet.addElement(
+                    PrioritizedLookupElement.withPriority(element, 100.0)
+                )
+            }
+
+        completionResultSet.stopHere()
+    }
+}

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
@@ -1,3 +1,23 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.demonwav.mcdev.platform.bukkit.completion
 
 import com.demonwav.mcdev.platform.bukkit.util.BukkitConstants

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
@@ -1,5 +1,8 @@
 package com.demonwav.mcdev.platform.bukkit.completion
 
+import com.demonwav.mcdev.platform.bukkit.util.BukkitConstants
+import com.demonwav.mcdev.util.findContainingClass
+import com.demonwav.mcdev.util.findContainingMethod
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
@@ -18,31 +21,33 @@ import com.intellij.util.ProcessingContext
 import org.jetbrains.annotations.NotNull
 
 class BukkitEventHandlerCompletionProvider : CompletionProvider<CompletionParameters>() {
-    companion object {
-        const val EVENT_LISTENER = "org.bukkit.event.Listener"
-        private const val BUKKIT_EVENT_FQN = "org.bukkit.event.Event"
-    }
 
     override fun addCompletions(
-        @NotNull completionParameters: CompletionParameters,
-        @NotNull processingContext: ProcessingContext,
-        @NotNull completionResultSet: CompletionResultSet
+        completionParameters: CompletionParameters,
+        processingContext: ProcessingContext,
+        completionResultSet: CompletionResultSet
     ) {
         val prefix = completionResultSet.prefixMatcher.prefix
-        if (!prefix.startsWith("on") || prefix.length == 2) return
+        if (!prefix.startsWith("on") || prefix.length == 2) {
+            return
+        }
 
         val position = completionParameters.position
-        val containingClass = PsiTreeUtil.getParentOfType(position, PsiClass::class.java) ?: return
-        val project: Project = position.project
-        val facade = JavaPsiFacadeEx.getInstanceEx(project)
+        val containingClass = position.findContainingClass() ?: return
+        val project = position.project
+        val facade = JavaPsiFacadeEx.getInstance(project)
 
-        val eventListenerClass = facade.findClass(EVENT_LISTENER, GlobalSearchScope.allScope(project)) ?: return
-        if (!containingClass.isInheritor(eventListenerClass, true)) return
-        if (PsiTreeUtil.getParentOfType(position, PsiMethod::class.java) != null) return
+        val eventListenerClass = facade.findClass(BukkitConstants.LISTENER_CLASS, GlobalSearchScope.allScope(project)) ?: return
+        if (!containingClass.isInheritor(eventListenerClass, true)) {
+            return
+        }
+
+        if (position.findContainingMethod() != null) {
+            return
+        }
 
         val scope = GlobalSearchScope.allScope(project)
-        val eventBaseClass = facade.findClass(BUKKIT_EVENT_FQN, scope) ?: return
-
+        val eventBaseClass = facade.findClass(BukkitConstants.EVENT_CLASS, scope) ?: return
         val eventNameFilter = prefix.substring(2).lowercase()
 
         ClassInheritorsSearch.search(eventBaseClass, scope, true)
@@ -57,7 +62,7 @@ class BukkitEventHandlerCompletionProvider : CompletionProvider<CompletionParame
                 }
 
                 val lookupString = "on$eventSimpleName"
-                val methodName = lookupString.replace("Event", "")
+                val methodName = lookupString.removeSuffix("Event")
                 val qualifiedName = psiClass.qualifiedName
 
                 val element = LookupElementBuilder

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
@@ -3,7 +3,7 @@
  *
  * https://mcdev.io/
  *
- * Copyright (C) 2025 minecraft-dev
+ * Copyright (C) 2026 minecraft-dev
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -93,7 +93,5 @@ class BukkitEventHandlerCompletionProvider : CompletionProvider<CompletionParame
                     PrioritizedLookupElement.withPriority(element, 100.0)
                 )
             }
-
-        completionResultSet.stopHere()
     }
 }

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerCompletionProvider.kt
@@ -29,16 +29,11 @@ import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.PrioritizedLookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.icons.AllIcons
-import com.intellij.openapi.project.Project
-import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.impl.JavaPsiFacadeEx
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ClassInheritorsSearch
-import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.ProcessingContext
-import org.jetbrains.annotations.NotNull
 
 class BukkitEventHandlerCompletionProvider : CompletionProvider<CompletionParameters>() {
 
@@ -82,7 +77,6 @@ class BukkitEventHandlerCompletionProvider : CompletionProvider<CompletionParame
                 }
 
                 val lookupString = "on$eventSimpleName"
-                val methodName = lookupString.removeSuffix("Event")
                 val qualifiedName = psiClass.qualifiedName
 
                 val element = LookupElementBuilder
@@ -93,7 +87,7 @@ class BukkitEventHandlerCompletionProvider : CompletionProvider<CompletionParame
                     .withIcon(AllIcons.Nodes.Method)
                     .withBaseLookupString(lookupString)
                     .withBoldness(true)
-                    .withInsertHandler(BukkitEventHandlerInsertHandler(methodName, qualifiedName))
+                    .withInsertHandler(BukkitEventHandlerInsertHandler(psiClass))
 
                 completionResultSet.addElement(
                     PrioritizedLookupElement.withPriority(element, 100.0)

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
@@ -3,7 +3,7 @@
  *
  * https://mcdev.io/
  *
- * Copyright (C) 2025 minecraft-dev
+ * Copyright (C) 2026 minecraft-dev
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
@@ -1,5 +1,6 @@
 package com.demonwav.mcdev.platform.bukkit.completion
 
+import com.demonwav.mcdev.platform.bukkit.util.BukkitConstants
 import com.intellij.codeInsight.completion.InsertHandler
 import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.lookup.LookupElement
@@ -13,11 +14,7 @@ class BukkitEventHandlerInsertHandler(
     private val qualifiedName: @NlsSafe String?
 ) : InsertHandler<LookupElement> {
 
-    companion object {
-        private const val EVENT_HANDLER_FQN = "org.bukkit.event.EventHandler"
-    }
-
-    override fun handleInsert(@NotNull insertionContext: InsertionContext, @NotNull lookupElement: LookupElement) {
+    override fun handleInsert(insertionContext: InsertionContext, lookupElement: LookupElement) {
         val project = insertionContext.project
         val editor = insertionContext.editor
 
@@ -25,7 +22,7 @@ class BukkitEventHandlerInsertHandler(
         val template = templateManager.createTemplate("", "")
         template.isToReformat = true
 
-        template.addTextSegment("@${EVENT_HANDLER_FQN}\n")
+        template.addTextSegment("@${BukkitConstants.HANDLER_ANNOTATION}\n")
         template.addTextSegment("public void ")
         template.addVariable("METHOD_NAME", TextExpression(methodName), true)
         template.addTextSegment("($qualifiedName ")
@@ -34,10 +31,10 @@ class BukkitEventHandlerInsertHandler(
         template.addEndVariable()
         template.addTextSegment("\n}")
 
-        insertionContext.getDocument().deleteString(
-            insertionContext.getStartOffset(),
-            insertionContext.getTailOffset()
-        );
+        insertionContext.document.deleteString(
+            insertionContext.startOffset,
+            insertionContext.tailOffset
+        )
 
         templateManager.startTemplate(editor, template)
 

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
@@ -1,0 +1,45 @@
+package com.demonwav.mcdev.platform.bukkit.completion
+
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.template.TemplateManager
+import com.intellij.codeInsight.template.impl.TextExpression
+import com.intellij.openapi.util.NlsSafe
+import org.jetbrains.annotations.NotNull
+
+class BukkitEventHandlerInsertHandler(
+    private val methodName: String,
+    private val qualifiedName: @NlsSafe String?
+) : InsertHandler<LookupElement> {
+
+    companion object {
+        private const val EVENT_HANDLER_FQN = "org.bukkit.event.EventHandler"
+    }
+
+    override fun handleInsert(@NotNull insertionContext: InsertionContext, @NotNull lookupElement: LookupElement) {
+        val project = insertionContext.project
+        val editor = insertionContext.editor
+
+        val templateManager = TemplateManager.getInstance(project)
+        val template = templateManager.createTemplate("", "")
+        template.isToReformat = true
+
+        template.addTextSegment("@${EVENT_HANDLER_FQN}\n")
+        template.addTextSegment("public void ")
+        template.addVariable("METHOD_NAME", TextExpression(methodName), true)
+        template.addTextSegment("($qualifiedName ")
+        template.addVariable("EVENT_PARAM", TextExpression("event"), true)
+        template.addTextSegment(") { \n")
+        template.addEndVariable()
+        template.addTextSegment("\n}")
+
+        insertionContext.getDocument().deleteString(
+            insertionContext.getStartOffset(),
+            insertionContext.getTailOffset()
+        );
+
+        templateManager.startTemplate(editor, template)
+
+    }
+}

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
@@ -1,3 +1,23 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.demonwav.mcdev.platform.bukkit.completion
 
 import com.demonwav.mcdev.platform.bukkit.util.BukkitConstants

--- a/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
+++ b/src/main/kotlin/platform/bukkit/completion/BukkitEventHandlerInsertHandler.kt
@@ -20,43 +20,39 @@
 
 package com.demonwav.mcdev.platform.bukkit.completion
 
-import com.demonwav.mcdev.platform.bukkit.util.BukkitConstants
+import com.demonwav.mcdev.util.psiType
 import com.intellij.codeInsight.completion.InsertHandler
 import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.intention.impl.TypeExpression
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.template.TemplateManager
-import com.intellij.codeInsight.template.impl.TextExpression
-import com.intellij.openapi.util.NlsSafe
-import org.jetbrains.annotations.NotNull
+import com.intellij.codeInsight.template.impl.TemplateSettings
+import com.intellij.codeInsight.template.impl.Variable
+import com.intellij.psi.PsiClass
+import com.jetbrains.rd.util.string.printToString
 
 class BukkitEventHandlerInsertHandler(
-    private val methodName: String,
-    private val qualifiedName: @NlsSafe String?
+    private val psiClass: PsiClass
 ) : InsertHandler<LookupElement> {
 
     override fun handleInsert(insertionContext: InsertionContext, lookupElement: LookupElement) {
-        val project = insertionContext.project
-        val editor = insertionContext.editor
-
-        val templateManager = TemplateManager.getInstance(project)
-        val template = templateManager.createTemplate("", "")
-        template.isToReformat = true
-
-        template.addTextSegment("@${BukkitConstants.HANDLER_ANNOTATION}\n")
-        template.addTextSegment("public void ")
-        template.addVariable("METHOD_NAME", TextExpression(methodName), true)
-        template.addTextSegment("($qualifiedName ")
-        template.addVariable("EVENT_PARAM", TextExpression("event"), true)
-        template.addTextSegment(") { \n")
-        template.addEndVariable()
-        template.addTextSegment("\n}")
-
         insertionContext.document.deleteString(
             insertionContext.startOffset,
             insertionContext.tailOffset
         )
 
-        templateManager.startTemplate(editor, template)
+        val sourceTemplate = TemplateSettings.getInstance().getTemplate("event_handler", "Bukkit") ?: return
+        val template = sourceTemplate.copy()
 
+        val classTypeExpr = TypeExpression(insertionContext.project, listOf(psiClass.psiType))
+
+        val index = template.variables.indexOfFirst { it.name == "EVENT_CLASS" }
+        if (index != -1) {
+            template.removeVariable(index)
+        }
+
+        template.addVariable(Variable("EVENT_CLASS", classTypeExpr, classTypeExpr, false, false));
+
+        TemplateManager.getInstance(insertionContext.project).startTemplate(insertionContext.editor, template)
     }
 }

--- a/src/main/kotlin/platform/bukkit/macro/BukkitEventNameMacro.kt
+++ b/src/main/kotlin/platform/bukkit/macro/BukkitEventNameMacro.kt
@@ -3,7 +3,7 @@
  *
  * https://mcdev.io/
  *
- * Copyright (C) 2025 minecraft-dev
+ * Copyright (C) 2026 minecraft-dev
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published

--- a/src/main/kotlin/platform/bukkit/macro/BukkitEventNameMacro.kt
+++ b/src/main/kotlin/platform/bukkit/macro/BukkitEventNameMacro.kt
@@ -1,3 +1,23 @@
+/*
+ * Minecraft Development for IntelliJ
+ *
+ * https://mcdev.io/
+ *
+ * Copyright (C) 2025 minecraft-dev
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, version 3.0 only.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package com.demonwav.mcdev.platform.bukkit.macro
 
 import com.intellij.codeInsight.template.Expression

--- a/src/main/kotlin/platform/bukkit/macro/BukkitEventNameMacro.kt
+++ b/src/main/kotlin/platform/bukkit/macro/BukkitEventNameMacro.kt
@@ -1,0 +1,22 @@
+package com.demonwav.mcdev.platform.bukkit.macro
+
+import com.intellij.codeInsight.template.Expression
+import com.intellij.codeInsight.template.ExpressionContext
+import com.intellij.codeInsight.template.Result
+import com.intellij.codeInsight.template.TextResult
+import com.intellij.codeInsight.template.macro.MacroBase
+
+class BukkitEventNameMacro : MacroBase("bukkitEventName", "Usage: bukkitEventName(ClassType)") {
+    override fun calculateResult(
+        params: Array<out Expression?>,
+        context: ExpressionContext?,
+        quick: Boolean
+    ): Result? {
+        val text = params[0]
+            ?.calculateResult(context)
+            ?.toString() ?: return null
+
+        val result = text.split("\\.").last().removeSuffix("Event")
+        return TextResult(result)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -532,6 +532,13 @@
         <library.presentationProvider
                 implementation="com.demonwav.mcdev.platform.bukkit.framework.ModernPaperPresentationProvider"/>
 
+        <!-- Bukkit Completion Contributor -->
+
+        <completion.contributor
+                language="JAVA"
+                implementationClass="com.demonwav.mcdev.platform.bukkit.completion.BukkitEventHandlerCompletionContributor"
+                order="first"/>
+
         <!--endregion-->
 
         <!--region SPONGE-->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -539,6 +539,10 @@
                 implementationClass="com.demonwav.mcdev.platform.bukkit.completion.BukkitEventHandlerCompletionContributor"
                 order="first"/>
 
+        <defaultLiveTemplates file="/liveTemplates/Bukkit.xml"/>
+
+        <liveTemplateMacro implementation="com.demonwav.mcdev.platform.bukkit.macro.BukkitEventNameMacro"/>
+
         <!--endregion-->
 
         <!--region SPONGE-->

--- a/src/main/resources/liveTemplates/Bukkit.xml
+++ b/src/main/resources/liveTemplates/Bukkit.xml
@@ -1,3 +1,23 @@
+<!--
+    Minecraft Development for IntelliJ
+
+    https://mcdev.io/
+
+    Copyright (C) 2025 minecraft-dev
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation, version 3.0 only.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
 <templateSet group="Bukkit">
     <template
             name="event_handler"

--- a/src/main/resources/liveTemplates/Bukkit.xml
+++ b/src/main/resources/liveTemplates/Bukkit.xml
@@ -1,0 +1,12 @@
+<templateSet group="Bukkit">
+    <template
+            name="event_handler"
+            value="@org.bukkit.event.EventHandler&#10;public void on$NAME$($EVENT_CLASS$ $PARAM_NAME$) {&#10;$END$&#10;}"
+            toReformat="true"
+            toShortenFQNames="true"
+            key="live.template.bukkit.event_handler.description"
+            resource-bundle="messages.MinecraftDevelopment">
+        <variable name="NAME" expression="bukkitEventName(EVENT_CLASS)" alwaysStopAt="true"/>
+        <variable name="PARAM_NAME" expression="&quot;event&quot;" alwaysStopAt="true"/>
+    </template>
+</templateSet>

--- a/src/main/resources/liveTemplates/Bukkit.xml
+++ b/src/main/resources/liveTemplates/Bukkit.xml
@@ -3,7 +3,7 @@
 
     https://mcdev.io/
 
-    Copyright (C) 2025 minecraft-dev
+    Copyright (C) 2026 minecraft-dev
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published

--- a/src/main/resources/messages/MinecraftDevelopment.properties
+++ b/src/main/resources/messages/MinecraftDevelopment.properties
@@ -370,3 +370,5 @@ template.provider.builtin.label=Built In
 template.provider.remote.label=Remote
 template.provider.local.label=Local
 template.provider.zip.label=Archive
+
+live.template.bukkit.event_handler.description=Create an event handler


### PR DESCRIPTION
Adds a completion contributor for Bukkit event handlers. 

It only works in a class that implements `org.bukkit.event.Listener`.

It uses templates to generate the method and provide opportunity to change method name and parameter name. 

https://github.com/user-attachments/assets/39d1b1d7-b902-4eb8-ae59-635cbb80d717

I initially created this as a poc after someone (Strokkur) posted a video of him doing something similar and wanted to try if i can implement the same logic using the plugin SDK. 

If this ends up getting added we can also add Strokkur as co-author for the idea if he wants to, i don't mind that. 

