### PR TITLE
Pass owner to navigator when it can be inferred from the target

### DIFF
--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/FieldInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/FieldInjectionPoint.kt
@@ -29,6 +29,7 @@ import com.intellij.codeInsight.completion.JavaLookupElementBuilder
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiArrayAccessExpression
 import com.intellij.psi.PsiClass
@@ -37,6 +38,7 @@ import com.intellij.psi.PsiLiteral
 import com.intellij.psi.PsiMethodReferenceExpression
 import com.intellij.psi.PsiModifier
 import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiUtil
 import com.intellij.util.ArrayUtilRt
 import org.objectweb.asm.Opcodes
@@ -87,7 +89,13 @@ class FieldInjectionPoint : QualifiedInjectionPoint<PsiField>() {
             ?.takeIf { it in Const.VALID_OPCODES } ?: -1
         val args = AtResolver.getArgs(at)
         val arrayAccess = getArrayAccessType(args)
-        return target?.let { MyNavigationVisitor(targetClass, it, opcode, arrayAccess) }
+        val ownerOrTarget = target?.owner?.let { ownerName ->
+            JavaPsiFacade.getInstance(targetClass.project).findClass(
+                ownerName.replace('/', '.'),
+                GlobalSearchScope.allScope(targetClass.project)
+            )
+        } ?: targetClass
+        return target?.let { MyNavigationVisitor(ownerOrTarget, it, opcode, arrayAccess) }
     }
 
     override fun doCreateCollectVisitor(

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/HeadInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/HeadInjectionPoint.kt
@@ -28,6 +28,7 @@ import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiStatement
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodNode
@@ -71,6 +72,9 @@ class HeadInjectionPoint : InjectionPoint<PsiElement>() {
 
     private class MyNavigationVisitor : NavigationVisitor() {
         private var firstStatement = true
+
+        override fun visitAnnotation(annotation: PsiAnnotation) {
+        }
 
         override fun visitStatement(statement: PsiStatement) {
             if (firstStatement) {

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/InvokeAssignInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/InvokeAssignInjectionPoint.kt
@@ -25,12 +25,14 @@ import com.demonwav.mcdev.util.MemberReference
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import com.intellij.psi.CommonClassNames
+import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiLiteral
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.ArrayUtilRt
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.ClassNode
@@ -91,7 +93,13 @@ class InvokeAssignInjectionPoint : AbstractMethodInjectionPoint() {
         target: MixinSelector?,
         targetClass: PsiClass,
     ): NavigationVisitor? {
-        return target?.let { MyNavigationVisitor(targetClass, it) }
+        val ownerOrTarget = target?.owner?.let { ownerName ->
+            JavaPsiFacade.getInstance(targetClass.project).findClass(
+                ownerName.replace('/', '.'),
+                GlobalSearchScope.allScope(targetClass.project)
+            )
+        } ?: targetClass
+        return target?.let { MyNavigationVisitor(ownerOrTarget, it) }
     }
 
     override fun doCreateCollectVisitor(

--- a/src/main/kotlin/platform/mixin/handlers/injectionPoint/InvokeInjectionPoint.kt
+++ b/src/main/kotlin/platform/mixin/handlers/injectionPoint/InvokeInjectionPoint.kt
@@ -35,6 +35,7 @@ import com.intellij.psi.PsiLiteral
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.PsiNewExpression
+import com.intellij.psi.search.GlobalSearchScope
 import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.MethodInsnNode
 import org.objectweb.asm.tree.MethodNode
@@ -54,7 +55,14 @@ class InvokeInjectionPoint : AbstractMethodInjectionPoint() {
         target: MixinSelector?,
         targetClass: PsiClass,
     ): NavigationVisitor? {
-        return target?.let { MyNavigationVisitor(targetClass, it) }
+        if (target == null) return null
+        val ownerOrTarget = target.owner?.let { ownerName ->
+            JavaPsiFacade.getInstance(targetClass.project).findClass(
+                ownerName.replace('/', '.'),
+                GlobalSearchScope.allScope(targetClass.project)
+            )
+        } ?: targetClass
+        return MyNavigationVisitor(ownerOrTarget, target)
     }
 
     override fun doCreateCollectVisitor(

--- a/src/main/kotlin/platform/mixin/util/AsmUtil.kt
+++ b/src/main/kotlin/platform/mixin/util/AsmUtil.kt
@@ -451,7 +451,8 @@ fun ClassNode.findSourceClass(project: Project, scope: GlobalSearchScope, canDec
             }
         }
         if (canDecompile) {
-            ((stubFile as? PsiCompiledFile)?.decompiledPsiFile as? PsiJavaFile)?.classes?.firstOrNull()
+            val javaFile = (stubFile as? PsiCompiledFile)?.decompiledPsiFile as? PsiJavaFile ?: stubFile as? PsiJavaFile
+            javaFile?.classes?.firstOrNull()
         } else {
             stubClass
         }


### PR DESCRIPTION
Following on from #2616 

As it turns out simply transforming the result of `getCustomOwner` was almost enough by itself, I just did it wrong in testing before 😅, however, when it comes to navigating to the target there were a couple of issues. Notably injection points would rely on the untransformed class passed from the `AtResolver` (providing the selector with enough context to transform that per #2616 would be a bit of a pain).
https://github.com/minecraft-dev/MinecraftDev/blob/66f57a651940ef2588bab9b001edd1c781e690e4/src/main/kotlin/platform/mixin/handlers/injectionPoint/AtResolver.kt#L230

 This results in the injection points looking for the target in the wrong class, so instead, where possible we trust the qualifier of the `target` (for `INVOKE`/`INVOKE_ASSIGN`/`FIELD`) to find the element, which ultimately seems to have done the trick for most injection points. 

Notably `HEAD` would wind up getting stuck in the target's injector annotation itself, resulting in a target resolution failure, so I opted to skip annotation visiting on that injection point navigator as there isn't any reason `HEAD` should point there anyway.

The injection points `CONSTANT`/`NEW`/`CTOR_HEAD` worked out the box which was convenient, however `MIXINEXTRAS:EXPRESSION` has a an issue that any definitions that reference a member "belonging" to the mixin will fail to navigate to from the gutter icon as eventually the qualifier will be queried on said member by ME's matching algorithm which will resolve as the mixin rather than the qualifier in the definition. If I were to make the same change to ME's matching it'd be to trust the definition qualifier when looking for the member rather than the AST's qualifier, however, I don't know the best way to implement that as there's a lot going on there.

This fails:
<img width="3438" height="1558" alt="Screenshot 2026-05-01 at 21 22 30" src="https://github.com/user-attachments/assets/8f2344be-2397-4a92-a1cb-2d56fe23a4af" />

This succeeds:
<img width="3420" height="1774" alt="Screenshot 2026-05-01 at 21 28 10" src="https://github.com/user-attachments/assets/f6d955af-bf02-4e45-9cb0-61fc733f1371" />



Also fixes source file lookup when referencing same-project / sibling-project class, as sometimes the file is already decompiled when you get it via `stubClass.containingFile`