### PR TITLE
Fix local file reference lookup on decomp

### DIFF
--- a/src/main/kotlin/platform/mixin/util/AsmUtil.kt
+++ b/src/main/kotlin/platform/mixin/util/AsmUtil.kt
@@ -451,7 +451,8 @@ fun ClassNode.findSourceClass(project: Project, scope: GlobalSearchScope, canDec
             }
         }
         if (canDecompile) {
-            ((stubFile as? PsiCompiledFile)?.decompiledPsiFile as? PsiJavaFile)?.classes?.firstOrNull()
+            val javaFile = (stubFile as? PsiCompiledFile)?.decompiledPsiFile as? PsiJavaFile ?: stubFile as? PsiJavaFile
+            javaFile?.classes?.firstOrNull()
         } else {
             stubClass
         }


### PR DESCRIPTION
Fixes source file lookup when referencing same-project / sibling-project class, as sometimes the file is already decompiled when you get it via `stubClass.containingFile`