### PR TITLE
Fix inconsistent package naming by forcing lowercase in SuggestClassNamePropertyDerivation

### DIFF
--- a/src/main/kotlin/creator/custom/derivation/SuggestClassNamePropertyDerivation.kt
+++ b/src/main/kotlin/creator/custom/derivation/SuggestClassNamePropertyDerivation.kt
@@ -25,16 +25,21 @@ import com.demonwav.mcdev.creator.custom.TemplateValidationReporter
 import com.demonwav.mcdev.creator.custom.model.BuildSystemCoordinates
 import com.demonwav.mcdev.creator.custom.model.ClassFqn
 import com.demonwav.mcdev.creator.custom.types.CreatorProperty
-import com.demonwav.mcdev.util.capitalize
-import com.demonwav.mcdev.util.decapitalize
+import com.intellij.openapi.util.text.StringUtil
 
 class SuggestClassNamePropertyDerivation : PreparedDerivation {
 
     override fun derive(parentValues: List<Any?>): Any {
         val coords = parentValues[0] as BuildSystemCoordinates
         val name = parentValues[1] as String
-        val sanitizedName = name.split(NOT_JAVA_IDENTIFIER).joinToString("", transform = String::capitalize)
-        return ClassFqn("${coords.groupId}.${sanitizedName.decapitalize()}.$sanitizedName")
+
+        val sanitizedName = name.split(NOT_JAVA_IDENTIFIER)
+            .joinToString("", transform = { StringUtil.capitalizeWords(it,true) })
+
+        val packageGroup = coords.groupId.lowercase()
+        val packageArtifact = sanitizedName.lowercase()
+
+        return ClassFqn("$packageGroup.$packageArtifact.$sanitizedName")
     }
 
     companion object : PropertyDerivationFactory {

--- a/src/main/kotlin/creator/step/MainClassStep.kt
+++ b/src/main/kotlin/creator/step/MainClassStep.kt
@@ -41,13 +41,14 @@ class MainClassStep(parent: NewProjectWizardStep) : AbstractNewProjectWizardStep
         val buildSystemProps = findStep<BuildSystemPropertiesStep<*>>()
 
         if (buildSystemProps.artifactId.contains('.')) {
-            // if the artifact id is invalid, don't confuse ourselves by copying its dots
             return className
         }
 
-        return buildSystemProps.groupId.toPackageName() +
-            "." + buildSystemProps.artifactId.toPackageName() +
-            "." + findStep<AbstractModNameStep>().name.toJavaClassName()
+        val group = buildSystemProps.groupId.toPackageName()
+        val artifact = buildSystemProps.artifactId.toPackageName()
+        val mainClassName = findStep<AbstractModNameStep>().name.toJavaClassName()
+
+        return "$group.$artifact.$mainClassName"
     }
 
     val classNameProperty = propertyGraph.lazyProperty(::suggestMainClassName)

--- a/src/test/kotlin/creator/ClassFqnCreatorPropertyTest.kt
+++ b/src/test/kotlin/creator/ClassFqnCreatorPropertyTest.kt
@@ -96,6 +96,6 @@ class ClassFqnCreatorPropertyTest : CreatorTemplateProcessorTestBase() {
 
         buildCoordsProperty.graphProperty.set(BuildSystemCoordinates("com.example.project", "example-project", "1.0"))
         nameProperty.graphProperty.set("My Project")
-        assertEquals(ClassFqn("com.example.project.myProject.MyProject"), fqnProperty.get())
+        assertEquals(ClassFqn("com.example.project.myproject.MyProject"), fqnProperty.get())
     }
 }


### PR DESCRIPTION
### Description
Currently, the `SuggestClassNamePropertyDerivation` class uses `decapitalize()` when generating the package part of the Main Class FQN. This leads to `camelCase` naming (e.g., `com.example.myProject`), which violates standard Java/Kotlin package naming conventions.

### Changes
- Replaced `.decapitalize()` with `.lowercase()` for the artifact/name segment of the package path.
- Added `.lowercase()` to `coords.groupId` to ensure the entire package path remains standard-compliant.

### Motivation
Java packages should always be lowercase. While the "Old Wizard" handled this correctly, the new Custom Wizard logic was preserving upper-case characters from the project name/artifact ID. This change aligns the custom wizard with professional development standards and the behavior seen in the Mod creation templates.