### PR TITLE
Make invoker follow accessor behavior

### DIFF
--- a/src/main/kotlin/platform/mixin/handlers/InvokerHandler.kt
+++ b/src/main/kotlin/platform/mixin/handlers/InvokerHandler.kt
@@ -91,7 +91,7 @@ class InvokerHandler : MixinMemberAnnotationHandler {
             return "<init>"
         }
         val name = result.groupValues[2]
-        if (name.uppercase(Locale.ENGLISH) != name) {
+        if (name.uppercase(Locale.ENGLISH) != name || name.length == 1) {
             return name.decapitalize()
         }
         return name


### PR DESCRIPTION
AccessorHandler currently decapitallizes single-letter accessors. I don't see why not for invokers. I understand this is not a perfect fix for all cases, but making both behave the same is probably a good place to start. Plus, capitalized methods are much rarer.